### PR TITLE
Updated to latest tableauserverclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ def main():
     # Download a datasource
     tdsx_path = ts.download_datasource(dsid=datasource_id, name=datasource_name, project=project_name)
     # Extract the TDS file from the TDSX for making updates
-    tds_path = tu.extract_tds(tdsx_path)
-    tds = tu.TDS(tds_path)
+    tds_dict = tu.extract_tds(tdsx_path)
+    tds = tu.TDS(tds_dict)
     # Add a column to the datasource
     tds.add(
         item_type='column',
@@ -58,7 +58,7 @@ def main():
         calculation='MAX([Created Datetime])'
     )
     # Update the datasource from alterations made to the TDS
-    tu.update_tdsx(tdsx_path, tds_path)
+    tu.update_tdsx(tdsx_path, tds_dict)
     # Publish the datasource
     ts.publish_datasource(tdsx_path, dsid=datasource_id, name=datasource_name, project=project_name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-tableauserverclient==0.13.0
+tableauserverclient==0.18.0
 xmltodict
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="1.0.0",
+    version="1.0.1",
     packages=['tableau_utilities'],
     package_data={"tableau_utilities": ["item_types.yml"]},
     include_package_data=True,

--- a/tableau_utilities/fetch_all_cols.py
+++ b/tableau_utilities/fetch_all_cols.py
@@ -42,8 +42,8 @@ def all_columns_all_datasources(server):
         os.mkdir('tmp_tdsx')
         shutil.move(tdsx, 'tmp_tdsx')
         os.chdir('tmp_tdsx')
-        tds_path = extract_tds(os.path.basename(tdsx))
-        columns = TDS(tds_path).list('column')
+        tds_dict = extract_tds(os.path.basename(tdsx))
+        columns = TDS(tds_dict).list('column')
         rows.extend(columns)
     return rows
 

--- a/tableau_utilities/tableau_utilities.py
+++ b/tableau_utilities/tableau_utilities.py
@@ -68,9 +68,9 @@ def update_tdsx(tdsx_path, tds):
                 path = z.extract(member=f, path=tdsx_dir)
                 extracted_files.append(path)
                 if f.filename.endswith('.tds'):
-                    tds_dict = path
+                    tds_path = path
         # Update tds file
-        with open(tds_dict, 'w') as tds_file:
+        with open(tds_path, 'w') as tds_file:
             tds_file.write(xmltodict.unparse(tds, pretty=True))
         # Repack the tdsx
         with ZipFile(temp_tdsx_path, 'w') as z:

--- a/tableau_utilities/tableau_utilities.py
+++ b/tableau_utilities/tableau_utilities.py
@@ -703,22 +703,11 @@ class TDS:
                 {name: self.__getattribute__(attr) for name, attr in identifier.items()}
                 for identifier in identifiers
             ]
-        # identifiers = []
-        # if item_type == 'folder':
-        #     identifiers = [
-        #         {"@name": self.folder_name, "@role": self.role},
-        #         {"@name": self.folder_name}
-        #     ]
-        # if item_type == 'column':
-        #     identifiers = [{"@name": self.column_name}]
-        # if item_type in ['datasource-metadata', 'datasource-metadata-cols', 'extract-metadata', 'extract-metadata-cols']:
-        #     identifiers = [{"remote-name": self.remote_name}]
+
         if item_type == 'connection':
             for item in section:
                 if item['connection']['@class'] == self.conn_type:
                     return item
-            # Only used for error message
-            # identifiers = [{"connection": {'@class': self.conn_type}}]
 
         for identifier in identifiers:
             try:

--- a/tableau_utilities/tableau_utilities.py
+++ b/tableau_utilities/tableau_utilities.py
@@ -68,9 +68,9 @@ def update_tdsx(tdsx_path, tds):
                 path = z.extract(member=f, path=tdsx_dir)
                 extracted_files.append(path)
                 if f.filename.endswith('.tds'):
-                    tds_path = path
+                    tds_dict = path
         # Update tds file
-        with open(tds_path, 'w') as tds_file:
+        with open(tds_dict, 'w') as tds_file:
             tds_file.write(xmltodict.unparse(tds, pretty=True))
         # Repack the tdsx
         with ZipFile(temp_tdsx_path, 'w') as z:
@@ -1048,8 +1048,8 @@ def main():
     if args.download_ds:
         tdsx = ts.download_datasource(args.id, name=args.name, project=args.project, include_extract=False)
         print(f'Downloaded to {tdsx}')
-    tds_path = extract_tds(tdsx)
-    tds = TDS(tds_path)
+    tds_dict = extract_tds(tdsx)
+    tds = TDS(tds_dict)
     if args.download_wb:
         ts.download_workbook(wbid=args.id, name=args.name, project=args.project,
                              include_extract=False)
@@ -1077,7 +1077,7 @@ def main():
             conn_role=args.conn_role, conn_db=args.conn_db, conn_schema=args.conn_schema,
             conn_host=args.conn_host, conn_warehouse=args.conn_warehouse
         )
-    update_tdsx(tdsx, tds_path)
+    update_tdsx(tdsx, tds_dict)
     if args.publish:
         ts.publish_datasource(tdsx, dsid=args.id, name=args.name, project=args.project)
     if args.embed_creds:

--- a/tableau_utilities/test_tableau_utilities.py
+++ b/tableau_utilities/test_tableau_utilities.py
@@ -48,9 +48,9 @@ def test_extract_tds():
 
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/test_data_source.tdsx', 'test_data_source.tdsx')
-        tds = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
-        assert isinstance(tds, type(collections.OrderedDict()))
+        assert isinstance(type(tds_dict), type(collections.OrderedDict))
 
 
 # TEST 3: update_tds()

--- a/tableau_utilities/test_tableau_utilities.py
+++ b/tableau_utilities/test_tableau_utilities.py
@@ -78,7 +78,7 @@ def test_add_column():
         caption = 'Cool Name'
         role = 'dimension'
         folder = 'tidy'
-        tds_path = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
         attribs = {
             'item_type': 'column',
@@ -87,7 +87,7 @@ def test_add_column():
             'folder_name': folder,
             'role': role
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.add(**attribs)
         col = tds.get(**attribs)
         folder = tds.get('folder', folder_name=folder, role=role)
@@ -110,7 +110,7 @@ def test_add_existing_column_fails():
         shutil.copyfile(f'resources/{folder}/test_data_source.tdsx', 'test_data_source.tdsx')
         args = add_column_args()
         add_existing_column_fails = False
-        tds_path = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
         attribs = {
             'item_type': 'column',
@@ -122,7 +122,7 @@ def test_add_existing_column_fails():
             'datatype': args.datatype,
             'desc': args.desc
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.add(**attribs)
         try:
             tds.add(**attribs)
@@ -137,11 +137,11 @@ def test_add_column_fails_with_wrong_folder():
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/test_data_source.tdsx', 'test_data_source.tdsx')
         args = add_column_args()
-        tds_path = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
         got_a_TableauUtilitiesError = False
         try:
-            tableau_utilities.TDS(tds_path).add(
+            tableau_utilities.TDS(tds_dict).add(
                 item_type='column',
                 column_name=args.column_name,
                 caption=args.caption,
@@ -163,14 +163,14 @@ def test_add_folder_tdsx_has_folder():
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/test_data_source.tdsx', 'test_data_source.tdsx')
         args = add_folder_args()
-        tds_path = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
         attribs = {
             'item_type': 'folder',
             'folder_name': args.folder_name,
             'role': args.role
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.add(**attribs)
         found_folder = tds.get(**attribs)
         assert found_folder is not None
@@ -182,14 +182,14 @@ def test_add_folder_tdsx_does_not_have_folder():
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/no_folder.tdsx', 'no_folder.tdsx')
         args = add_folder_args()
-        tds_path = tableau_utilities.extract_tds('no_folder.tdsx')
+        tds_dict = tableau_utilities.extract_tds('no_folder.tdsx')
         os.remove('no_folder.tdsx')
         attribs = {
             'item_type': 'folder',
             'folder_name': args.folder_name,
             'role': args.role
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.add(**attribs)
         found_folder = tds.get(**attribs)
         assert found_folder is not None
@@ -201,14 +201,14 @@ def test_add_folder_tdsx_has_one_folder():
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/one_folder.tdsx', 'one_folder.tdsx')
         args = add_folder_args()
-        tds_path = tableau_utilities.extract_tds('one_folder.tdsx')
+        tds_dict = tableau_utilities.extract_tds('one_folder.tdsx')
         os.remove('one_folder.tdsx')
         attribs = {
             'item_type': 'folder',
             'folder_name': args.folder_name,
             'role': args.role
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.add(**attribs)
         found_folder = tds.get(**attribs)
         assert found_folder is not None
@@ -220,7 +220,7 @@ def test_add_existing_folder_fails():
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/test_data_source.tdsx', 'test_data_source.tdsx')
         args = add_folder_args()
-        tds_path = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
         add_existing_folder_fails = False
         attribs = {
@@ -228,7 +228,7 @@ def test_add_existing_folder_fails():
             'folder_name': args.folder_name,
             'role': args.role
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.add(**attribs)
         try:
             tds.add(**attribs)
@@ -243,14 +243,14 @@ def test_delete_folder():
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/test_data_source.tdsx', 'test_data_source.tdsx')
         args = add_folder_args()
-        tds_path = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
         attribs = {
             'item_type': 'folder',
             'folder_name': args.folder_name,
             'role': args.role
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.add(**attribs)
         tds.delete(**attribs)
         found_folder = tds.get(**attribs)
@@ -262,14 +262,14 @@ def test_modify_column():
 
     for folder in ['latest_xml_structure', 'legacy_xml_structure']:
         shutil.copyfile(f'resources/{folder}/test_data_source.tdsx', 'test_data_source.tdsx')
-        tds_path = tableau_utilities.extract_tds('test_data_source.tdsx')
+        tds_dict = tableau_utilities.extract_tds('test_data_source.tdsx')
         os.remove('test_data_source.tdsx')
         attribs = {
             'item_type': 'column',
             'column_name': 'QUANTITY',
             'caption': 'Quantity'
         }
-        tds = tableau_utilities.TDS(tds_path)
+        tds = tableau_utilities.TDS(tds_dict)
         tds.update(**attribs)
         col = tds.get(**attribs)
         assert col['@caption'] == 'Quantity'


### PR DESCRIPTION
# Summary
Some functionality, namely the `list_workbooks` function of `TableauServer`, would error with:
```
ValueError: project_id must be defined.
```
Seems this was fixed in a later version of `tableauserverclient`.

# Changes
- Brought `tableauserverclient` requirement up to the latest `0.18.0` version.
- Increment `tableau_utilities` version
- Minor changes:
  - Changed some variable names to be more accurate `tds_path` is really a `tds_dict`
  - Fixed an issue with a test not properly comparing types
  - Removed some commented out code