### PR TITLE
Fixed a bug that would error when trying to update extract metadata for live connections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="1.0.2",
+    version="1.0.3",
     packages=['tableau_utilities'],
     package_data={"tableau_utilities": ["item_types.yml"]},
     include_package_data=True,

--- a/tableau_utilities/tableau_utilities.py
+++ b/tableau_utilities/tableau_utilities.py
@@ -527,7 +527,7 @@ class TDS:
             raise TableauUtilitiesError('Missing local or remote name')
         for item_type in ['datasource-metadata', 'extract-metadata']:
             section = self.__get_section(item_type)
-            if not section:
+            if not section and item_type == 'datasource-metadata':
                 raise TableauUtilitiesError('Metadata does not exist')
             metadata = self.__get_item(item_type, section)
             if metadata:
@@ -552,7 +552,7 @@ class TDS:
                 # Set the mapping for the metadata and column
                 self.__set_cols_mapping(item_type, old_local_name, new_local_name, table=metadata["parent-name"])
 
-            else:
+            elif item_type == 'datasource-metadata':
                 raise TableauUtilitiesError('Metadata does not exist')
 
     def __set_cols_mapping(self, item_type, old_local_name, new_local_name, table):


### PR DESCRIPTION
# Summary
When attempting to add a column to a datasource with a live connection, sometimes it will throw this error:
```
Metadata does not exist
```
This happens because added/updated columns will have the metadata enforced. When updating metadata for a datasource with an extract, there are two sections where metadata is stored and updated - the connection and the extract connection. However, live connections typically do not have any extract connection metadata, which is why this error appears for live connections. If this error does not happen for a live connection, it is because that extract metadata is lingering from an old extract connection.

# Changes
- Updated the 'Metadata does not exist' error to only appear for `datasource-metadata`
  - Datasources with either `extract` or `live` connections should have `datasource-metadata`, so if it is not found, it should throw an error
  - If `extract-metadata` is missing, it will be skipped without an error
    - It is expected that live connections should not have `extract-metadata`

# Tests
- [x] Tested locally on a datasource know to give this error
  - datasource-metadata was updated
- [x] Tested locally on a datasource that did not give this error
  - datasource-metadata was updated
  - extract-metadata was updated