### PR TITLE
Fix airflow example for Airflow 2.0

### DIFF
--- a/airflow_example/dags/tableau_datasource_update/tableau_datasource_update.py
+++ b/airflow_example/dags/tableau_datasource_update/tableau_datasource_update.py
@@ -11,7 +11,7 @@ import shutil
 import re
 import ast
 from copy import deepcopy
-from tdscc import TDS, TableauServer, extract_tds, update_tdsx, TDSCCError
+from tableau_utilities import TDS, TableauServer, extract_tds, update_tdsx, TableauUtilitiesError
 
 from airflow import DAG, models
 from airflow.operators.python_operator import PythonOperator
@@ -103,7 +103,7 @@ def refresh_datasource(tasks, tableau_conn_id='tableau_default', snowflake_conn_
         ts.refresh_datasource(tasks["dsid"])
         logging.info('Refreshed %s %s', tasks["dsid"], tasks['datasource_name'])
     except Exception as error:
-        if isinstance(error, TDSCCError) or 'Not queuing a duplicate.' in str(error):
+        if isinstance(error, TableauUtilitiesError) or 'Not queuing a duplicate.' in str(error):
             logging.info(error)
             logging.info('Skipping Refresh %s %s ... Already running',
                          tasks["dsid"], tasks['datasource_name'])
@@ -489,7 +489,7 @@ class TableauDatasourceUpdate(models.BaseOperator):
             try:
                 logging.info('Going to %s %s: %s -- %s', item_type, tdsx, item)
                 TDS(tds=self.tds).__getattribute__(action)(item_type, **item)
-            except TDSCCError as err:
+            except TableauUtilitiesError as err:
                 # If a source is updated again before it has refreshed in tableau,
                 # it will not detect the folders in the source, and try to add them all again
                 if item_type == 'folder' and action == 'add':

--- a/airflow_example/dags/tableau_datasource_update/tableau_datasource_update.py
+++ b/airflow_example/dags/tableau_datasource_update/tableau_datasource_update.py
@@ -480,7 +480,6 @@ class TableauDatasourceUpdate(models.BaseOperator):
         # Set on execute
         self.tasks = None
         self.tds = None
-        # self.tasks_task_id = None
         super().__init__(*args, **kwargs)
 
     def __has_any_task(self):

--- a/airflow_example/dags/tableau_datasource_update/tableau_datasource_update.py
+++ b/airflow_example/dags/tableau_datasource_update/tableau_datasource_update.py
@@ -185,7 +185,7 @@ class TableauDatasourceTasks(models.BaseOperator):
         Returns: True, False, or None if the folder doesn't exist.
         """
 
-        folder = TDS(tds=self.td).get('folder', **col_attributes)
+        folder = TDS(tds=self.tds).get('folder', **col_attributes)
         if not folder:
             return None
         if folder.get('folder-item') is None:


### PR DESCRIPTION
@JustinGrilli  Here are a couple of changes. I don't have the DAG working yet and I'm getting this error in Airflow UI:

```
Broken DAG: [/usr/local/airflow/dags/tableau/tableau_datasource_update.py] Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/airflow/models/baseoperator.py", line 188, in apply_defaults
    result = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/models/baseoperator.py", line 535, in __init__
    raise AirflowException(
airflow.exceptions.AirflowException: Invalid arguments were passed to TableauDatasourceTasks (task_id: add_tasks_salesforce_opportunity). Invalid arguments were:
**kwargs: {'snowflake_conn_id': 'snowflake_tableau_datasource', 'tableau_conn_id': 'tableau_default', 'datasource_name': 'Salesforce Opportunity', 'project': 'All', 'column_cfg': {'Salesforce Opportunity': {'Salesforce Account Id': {'description': 'The 18 
```

Once we figure that out I'll add any other changes here.