### PR TITLE
Fixed an issue with enforcing columns for datasources with a live connection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.1",
+    version="2.0.2",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -204,7 +204,7 @@ class Datasource(TableauFile):
             datasource_record = self.connection.metadata_records.get(remote_name)
             datasource_record.local_name = column.name
             self.connection.metadata_records.update(datasource_record)
-            extract_record = self.extract.connection.metadata_records.get(remote_name)
+            extract_record = self.extract.connection.metadata_records.get(remote_name) if self.extract else None
             if extract_record:
                 extract_record.local_name = column.name
                 self.extract.connection.metadata_records.update(extract_record)
@@ -213,7 +213,7 @@ class Datasource(TableauFile):
                 self.connection.cols.append(
                     tfo.MappingCol(key=column.name, value=f'{datasource_record.parent_name}.[{remote_name}]')
                 )
-            if column.name not in self.extract.connection.cols and extract_record:
+            if extract_record and column.name not in self.extract.connection.cols:
                 self.extract.connection.cols.append(
                     tfo.MappingCol(key=column.name, value=f'{extract_record.parent_name}.[{remote_name}]')
                 )


### PR DESCRIPTION
# Summary
`Datasource.enforce_column()` will throw an error when used on a datasource with a live connection, if `remote_name` is provided.
This happens because it will attempt to update `extract` metadata; tho live connections do not have an `extract` section, of course.

# Changes
- Updated `Datasource.enforce_column` logic to check for, and only update, the `extract` metadata, if that section exists