### PR TITLE
Update to the Datsource.connection.update() functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.3",
+    version="2.0.4",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/scripts/datasource.py
+++ b/tableau_utilities/scripts/datasource.py
@@ -147,12 +147,15 @@ def datasource(args, server=None):
     if enforce_connection:
         if debugging_logs:
             print(f'Updating the datasource connection: {color.fg_cyan}{conn_type}{color.reset}')
-        ds.connection.named_connections[conn_type].connection.server = conn_host
-        ds.connection.named_connections[conn_type].connection.username = conn_user
-        ds.connection.named_connections[conn_type].connection.service = conn_role
-        ds.connection.named_connections[conn_type].connection.dbname = conn_db
-        ds.connection.named_connections[conn_type].connection.schema = conn_schema
-        ds.connection.named_connections[conn_type].connection.warehouse = conn_warehouse
+        ds.connection.update(tfo.Connection(
+            class_name=conn_type,
+            server=conn_host,
+            username=conn_user,
+            service=conn_role,
+            dbname=conn_db,
+            schema=conn_schema,
+            warehouse=conn_warehouse
+        ))
 
     # Save the datasource if an edit may have happened
     if column_name or folder_name or delete or enforce_connection:

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -930,6 +930,7 @@ class ParentConnection(TableauFileObject):
         Returns: The TableauFileObject Connection object
         """
         if item.class_name in self.named_connections:
+            self.named_connections[item.class_name].caption = item.server
             self.named_connections[item.class_name].connection = item
 
     def dict(self):

--- a/tableau_utilities/test_tableau_utilities.py
+++ b/tableau_utilities/test_tableau_utilities.py
@@ -21,7 +21,7 @@ COLUMN = tfo.Column(
 FOLDER = tfo.Folder(name='Friendly Name')
 
 
-# TEST 1: cli.parser args
+# cli.parser args
 def test_cli_local_args():
     argv = [
         '-l', 'local',
@@ -33,7 +33,7 @@ def test_cli_local_args():
     assert args.file_path == EXTRACT_PATH
 
 
-# TEST 2: cli.parser args
+# cli.parser args
 def test_cli_server_info_args():
     argv = [
         '-tn', 'token_name',
@@ -49,7 +49,7 @@ def test_cli_server_info_args():
     assert args.server == 'us-east-1'
 
 
-# TEST 3: Column()
+# Column()
 def test_column_attributes():
     column_attributes = {
         'name': '[FRIENDLY_CALC]',
@@ -69,7 +69,7 @@ def test_column_attributes():
             assert value == getattr(column2, attr)
 
 
-# TEST 4: Datasource().DatasourceItems
+# Datasource().DatasourceItems
 def test_datasource_items():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -81,7 +81,7 @@ def test_datasource_items():
     assert datasource.extract is not None and datasource.extract != []
 
 
-# TEST 5: Datasource().unzip()
+# Datasource().unzip()
 def test_unzip_tableau_file():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     path = tu.Datasource(EXTRACT_PATH).unzip()
@@ -92,7 +92,7 @@ def test_unzip_tableau_file():
     assert content is not None
 
 
-# TEST 6: Datasource().save()
+# Datasource().save()
 def test_datasource_save():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource_before = tu.Datasource(EXTRACT_PATH)
@@ -103,7 +103,7 @@ def test_datasource_save():
         assert before == after
 
 
-# TEST 7: Datasource().columns.add()
+# Datasource().columns.add()
 def test_add_column():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -113,7 +113,7 @@ def test_add_column():
     assert column is not None
 
 
-# TEST 8: Datasource().enforce_column()
+# Datasource().enforce_column()
 def test_enforce_column():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -134,7 +134,7 @@ def test_enforce_column():
     assert metadata.local_name == '[renamed_name]'
 
 
-# TEST 9: Datasource().columns.add()
+# Datasource().columns.add()
 def test_add_existing_column():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -144,7 +144,7 @@ def test_add_existing_column():
     assert len([c for c in datasource.columns if c == COLUMN]) == 1
 
 
-# TEST 10: Datasource().folders_common.folder.add()
+# Datasource().folders_common.folder.add()
 def test_add_folder_tdsx_has_folder():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -154,7 +154,7 @@ def test_add_folder_tdsx_has_folder():
     assert found_folder is not None
 
 
-# TEST 11: Datasource().folders_common.folder.add()
+# Datasource().folders_common.folder.add()
 def test_add_folder_tdsx_does_not_have_folder():
     shutil.copyfile(f'resources/{NO_FOLDER_PATH}', NO_FOLDER_PATH)
     datasource = tu.Datasource(NO_FOLDER_PATH)
@@ -164,7 +164,7 @@ def test_add_folder_tdsx_does_not_have_folder():
     assert found_folder is not None
 
 
-# TEST 12: Datasource().folders_common.folder.add()
+# Datasource().folders_common.folder.add()
 def test_add_folder_tdsx_has_one_folder():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -174,7 +174,7 @@ def test_add_folder_tdsx_has_one_folder():
     assert found_folder is not None
 
 
-# TEST 13: Datasource().folders_common.add()
+# Datasource().folders_common.add()
 def test_add_existing_folder():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -184,7 +184,7 @@ def test_add_existing_folder():
     assert len([f for f in datasource.folders_common if f == FOLDER]) == 1
 
 
-# TEST 14: Datasource().folders_common.delete()
+# Datasource().folders_common.delete()
 def test_delete_folder():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -195,7 +195,7 @@ def test_delete_folder():
     assert not found_folder
 
 
-# TEST 15: Datasource().columns.update()
+# Datasource().columns.update()
 def test_update_column():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     datasource = tu.Datasource(EXTRACT_PATH)
@@ -212,7 +212,7 @@ def test_update_column():
     assert col.caption == 'Quantity Renamed'
 
 
-# TEST 16: Datasource().folders_common.get()
+# Datasource().folders_common.get()
 def test_get_folder():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     shutil.copyfile(f'resources/{LIVE_PATH}', LIVE_PATH)
@@ -228,7 +228,7 @@ def test_get_folder():
     assert ds_one_folder.folders_common.get('neat') is not None
 
 
-# TEST 17: Datasource().folders_common
+# Datasource().folders_common
 def test_find_all_folders():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     shutil.copyfile(f'resources/{LIVE_PATH}', LIVE_PATH)
@@ -248,7 +248,7 @@ def test_find_all_folders():
     assert _folder_one_folder == ['neat']
 
 
-# TEST 18: Datasource().columns
+# Datasource().columns
 def test_find_all_columns():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     shutil.copyfile(f'resources/{LIVE_PATH}', LIVE_PATH)
@@ -270,7 +270,7 @@ def test_find_all_columns():
     ]
 
 
-# TEST 19: Datasource().connection.relation.connection
+# Datasource().connection.relation.connection
 def test_find_all_connections():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     shutil.copyfile(f'resources/{LIVE_PATH}', LIVE_PATH)
@@ -282,7 +282,7 @@ def test_find_all_connections():
     assert ds_live.connection.named_connections == ['snowflake']
 
 
-# TEST 20: get_connections()
+# get_connections()
 def test_get_connection():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     shutil.copyfile(f'resources/{LIVE_PATH}', LIVE_PATH)
@@ -294,7 +294,7 @@ def test_get_connection():
     assert ds_live.connection.named_connections.get('snowflake') is not None
 
 
-# TEST 21: Datasource().connection.update()
+# Datasource().connection.update()
 def test_update_connection():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
     shutil.copyfile(f'resources/{LIVE_PATH}', LIVE_PATH)
@@ -313,7 +313,7 @@ def test_update_connection():
     )
     ds_extract.connection.update(connection)
     ds_live.connection.update(connection)
-    tds_extract_conn = ds_extract.connection.get('snowflake')
-    tds_live_conn = ds_live.connection.get('snowflake')
-    assert tds_extract_conn.dbname == 'FAKE_DB'
-    assert tds_live_conn.dbname == 'FAKE_DB'
+    assert ds_extract.connection.named_connections['snowflake'].caption == connection.server
+    assert ds_live.connection.named_connections['snowflake'].caption == connection.server
+    assert ds_extract.connection['snowflake'].dbname == 'FAKE_DB'
+    assert ds_live.connection['snowflake'].dbname == 'FAKE_DB'


### PR DESCRIPTION
# Summary
Currently updating the Datsource.connection will not update the `caption` of the `NamedConnection` object.
![image](https://github.com/hoverinc/tableau-utilities/assets/37851359/5c8f19dd-01a6-4ef3-a15a-103b42260eb1)
The `NamedConnection.caption` should match the `Connection.server`.

# Changes
- Added functionality to the `ParentConnection.update()` to update the `NamedConnection.caption`
- Updated logic in the `datasource` CLI to use `Datasource.connection.update()` to update a connection
- Updated test for `Datasource.connection.update()`
  - Removed test numbers from comments above the test

# Tests
- Ran updated test for `Datasource.connection.update()`