### PR TITLE
Fixed issues with connections in Tableau Datasources on save

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.4",
+    version="2.0.5",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',


### PR DESCRIPTION
# Summary
There are a number of issues with updating a Datasource Tableau object:
- When updating a Datasource with an extract, the extract data is removed from the archive (tdsx) file - so it cannot be published
- The CLI is not keeping attributes from an updated connection when those attributes are not provided
- The `refresh-event` element is not properly defined and formatted
- The encoding was not defined with writing the updated tds/twb for a TableauFile object

# Changes
- Update so a `TableauFile.save()` will include all files, not just the twb/tds that was updated
- Updated datasource CLI to keep attributes of a connection, when those attributes are not provided
- Updated datasource CLI to extract all data when saving the tds before/after (on `--save_tds` call)
- Defined dataclass for the `refresh-event` element
- Specified encoding when writing the updated tds/twb for a TableauFile object
- Fixed `super().__post_init__()` not being called in several child `TableauFile` objects

# Tests
- [x] `tableau_utilities -d -l online -n 'Orgs Discounts' -pn 'Official Datasources - Business' -f 'Orgs Discounts.tdsx' -tds --include_extract datasource --enforce_connection`
  - Checked to be sure the `refresh-event` element was properly formatted in the XML
- [x] `tableau_utilities -d -n 'Orgs Discounts' -pn 'Official Datasources - Business' -f 'Orgs Discounts.tdsx' server_operate --publish datasource`
