### PR TITLE
Updated datasource CLI and fixed TableauFile equality checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.61",
+    version="2.0.62",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/scripts/datasource.py
+++ b/tableau_utilities/scripts/datasource.py
@@ -105,14 +105,14 @@ def datasource(args, server=None):
         # Column name needs to be enclosed in brackets
         if debugging_logs:
             print('Going to add/update column:', column_name)
-        column_name = f'[{column_name}]'
         column = ds.columns.get(column_name)
-        persona = dict()
-        if args.persona:
-            persona = personas.get(args.persona.lower(), {})
+        if persona:
+            persona = personas.get(persona.lower(), {})
+        else:
+            persona = dict()
 
         if not column:
-            if not args.persona:
+            if not persona:
                 raise Exception('Column does not exist, and more args are need to add a new column.\n'
                                 f'Minimum required args: {color.fg_yellow}--column_name --persona{color.reset}')
             column = tfo.Column(

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -277,16 +277,16 @@ class Column(TableauFileObject):
     def __eq__(self, other):
         name = ''
         if isinstance(other, str):
-            name = other.lower()
+            name = other
         elif isinstance(other, dict):
-            name = other.get('name').lower()
+            name = other.get('name')
         elif isinstance(other, (Column, object)):
-            name = other.name.lower()
+            name = other.name
 
         if not re.match(r'^\[.+]$', name):
             name = f'[{name}]'
 
-        return self.name.lower() == name
+        return self.name == name
 
     def dict(self):
         output = {
@@ -413,16 +413,16 @@ class MappingCol(TableauFileObject):
     def __eq__(self, other):
         key = ''
         if isinstance(other, str):
-            key = other.lower()
+            key = other
         elif isinstance(other, dict):
-            key = other.get('key').lower()
+            key = other.get('key')
         elif isinstance(other, (MappingCol, object)):
-            key = other.key.lower()
+            key = other.key
 
         if not re.match(r'^\[.+]$', key):
             key = f'[{key}]'
 
-        return self.key.lower() == key
+        return self.key == key
 
     def dict(self):
         return {'@key': self.key, '@value': self.value}


### PR DESCRIPTION
# Summary of changes
- Fixed so `datasource` `--column_name` can be provided with surrounding `[]`
- Fixed equality checks for `Column` and `MappingCol`; They should have matching case (upper or lower)