### PR TITLE
Updated Datasource.enforce_column

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.62",
+    version="2.0.63",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',


### PR DESCRIPTION
# Summary
Currently, if a column's remote_name is already mapped for a column, in the connection, it will add an additional mapping for the same remote_name.
It should remove the old mapping, if it exists for a different local_name.

# Changes
- Generally reformatted the Datasource.enforce_column
  - Should improve readability
  - Added better error messaging
- Logic for updating MappingCols for the connection/extract will now delete any old mapping for the same remote_name