### PR TITLE
Fix parent connection update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.65",
+    version="2.0.66",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -997,6 +997,8 @@ class ParentConnection(TableauFileObject):
         if item.class_name in self.named_connections:
             self.named_connections[item.class_name].caption = item.server
             self.named_connections[item.class_name].connection = item
+            if item.schema and self.relation.type == 'table':
+                self.relation.table = f'[{item.schema}].' + self.relation.table.split('.')[-1]
 
     def dict(self):
         dictionary = {'@class': self.class_name}


### PR DESCRIPTION
# Summary & Changes
When using the `ParentConnection.update()` functionality, if the `schema` of the connection is difference than the existing connection, the `Relation` table will not get updated.
This causes issues when the metadata updates for the new connection (it will use the metadata of the original table).
- Added functionality to the `ParentConnection.update()` to update the `Relation.table` for the new `Connection.schema`