### PR TITLE
Added an attribute to a TableauFile for has_extract_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.66",
+    version="2.0.67",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -33,6 +33,7 @@ class TableauFile:
         ''' Set on init '''
         self._tree: ET.ElementTree
         self._root: ET.Element
+        self.has_extract_data: bool = False
         self.__extract_xml()
 
     def __extract_xml(self, path=None):
@@ -50,6 +51,7 @@ class TableauFile:
             with ZipFile(path) as zip_file:
                 for z in zip_file.filelist:
                     if z.filename.split('.')[-1] not in ['tds', 'twb']:
+                        self.has_extract_data = True
                         continue
                     self._tree = ET.parse(zip_file.open(z.filename))
                     self._root = self._tree.getroot()


### PR DESCRIPTION
# Summary
In some cases, it is useful to know if the TableauFile you are working with has the Extract data included.
So I want to add a flag to the TableauFile object, which indicates if it found Extract data when parsing the XML.

# Changes
- Added a flag to the `TableauFile` object for `has_extract_data`

# Tests
- Downloaded a Datasource with the extract
  - TableauFile of this datasource indicated `has_extract_data = True`
- Downloaded a Datasource without the extract
  - TableauFile of this datasource indicated `has_extract_data = False`