### PR TITLE
Added functionality to a Datasource for deleting a section from the XML

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.67",
+    version="2.0.68",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/test_tableau_utilities.py
+++ b/tableau_utilities/test_tableau_utilities.py
@@ -103,6 +103,18 @@ def test_datasource_save():
         assert before == after
 
 
+# del Datasource().<section>
+def test_delete_datasource_section():
+    shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)
+    datasource_before = tu.Datasource(EXTRACT_PATH)
+    extract_before = datasource_before.extract
+    del datasource_before.extract
+    datasource_before.save()
+    datasource_after = tu.Datasource(EXTRACT_PATH)
+    os.remove(EXTRACT_PATH)
+    assert extract_before and not datasource_after.extract
+
+
 # Datasource().columns.add()
 def test_add_column():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)


### PR DESCRIPTION
# Summary
In some cases we may want to delete an entire section from a Datasource.
We can utilize the built in `del` Python syntax to delete a section; i.e. `del Datasource.columns`

# Changes
- Created a function: `Datasource.__remove_section_from_parent`
  - For removing a section from a parent Element
- Implemented `Datasource.__delattr__` to call `__remove_section_from_parent`
- Replaced repeated code in `Datasource.save` function to use `__remove_section_from_parent`
- Added a test for `del Datasource.section` functionality

# Tests
- Used `del Datasource.<section>`:
  - `del datasource.extract`
  - `datasource.save()`
  - Confirmed extract was removed from the XML