### PR TITLE
Fixed recursion bug with TableauFileObjects.pop(), and added a test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.0.68",
+    version="2.0.69",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -212,9 +212,9 @@ class TableauFileObjects(list):
         Returns: The Tableau FileObject
         """
         if isinstance(item, int):
-            return self.pop(item)
+            return super().pop(item)
         else:
-            return self.pop(self.index(item))
+            return super().pop(self.index(item))
 
     def xml(self):
         """ Returns the TableauFileObjects as an XML Element """

--- a/tableau_utilities/test_tableau_utilities.py
+++ b/tableau_utilities/test_tableau_utilities.py
@@ -69,6 +69,21 @@ def test_column_attributes():
             assert value == getattr(column2, attr)
 
 
+# TableauFileObjects().pop()
+def test_tableau_file_objects_pop():
+    column = tfo.Column(**{
+        'name': '[FRIENDLY_CALC]',
+        'caption': 'Friendly Calc',
+        'datatype': 'integer',
+        'type': 'ordinal',
+        'role': 'dimension',
+        'desc': 'Nice and friendly',
+    })
+    columns = tfo.TableauFileObjects([column])
+    columns.pop(column)
+    assert len(columns) == 0
+
+
 # Datasource().DatasourceItems
 def test_datasource_items():
     shutil.copyfile(f'resources/{EXTRACT_PATH}', EXTRACT_PATH)


### PR DESCRIPTION
# Summary
There is a recursion bug with the TableauFileObjects.pop() function, because it is calling `self.pop()` within the `pop` function.

# Changes
- Fixed recursion in `TableauFileObjects.pop()` function
- Added a test for `TableauFileObjects.pop()`