### PR TITLE
Added logging for TableauFile.save and TableauServer.Publish

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.1.11",
+    version="2.1.12",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -1,3 +1,4 @@
+import logging
 import xml.etree.ElementTree as ET
 import os
 import shutil
@@ -102,15 +103,18 @@ class TableauFile:
             with ZipFile(temp_path) as z:
                 for f in z.filelist:
                     ext = f.filename.split('.')[-1]
+                    logging.info('Extracting file {}'.format(f.filename))
                     path = z.extract(member=f, path=temp_folder)
                     extracted_files.append(path)
                     if ext in ['tds', 'twb']:
                         xml_path = path
             # Update XML file
+            logging.info('Extracting updating XML {}'.format(xml_path))
             self._tree.write(xml_path, encoding="utf-8", xml_declaration=True)
             # Repack the unzipped file
             with ZipFile(temp_path, 'w') as z:
                 for file in extracted_files:
+                    logging.info('Archiving {}'.format(file))
                     arcname = file.split(temp_folder)[-1]
                     z.write(file, arcname=arcname)
             # Move file back to the original folder and remove any unpacked contents


### PR DESCRIPTION
# Summary
We need more visibility into the operations happening when TableauFile is saving and TableauServer is publishing.
Also, want to test changing the amount uploaded at a time while publishing to be less, as it may help fix the timeout errors we are seeing in Airflow.

# Changes
- Added logging:
  - TableauFile.save
  - TableauServer.Publish
- Reduced the `chunk_size_mb` from `50` to `5` in `TableauServer.Publish.__upload_in_chunks`