### PR TITLE
Package optional subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ A module and CLI Utility for managing Tableau objects, locally, and in Tableau O
 ### Installation
 
 #### From pypi
+
+##### Core Package
 - `pip install tableau-utilities`
+
+##### Hyper Subpackage
+This extra package depends on the tableauhyperapi which is incompatible with Apple Silicon computers.  See the [tableauhyperapi installation docs](https://tableau.github.io/hyper-db/docs/installation) for workarounds to use the package on Applie Silicon.
+
+- `pip install tableau-utilities[hyper]`
+- `pip install 'tableau-utilities[hyper]'`  if you're using zsh makes sure to add quotes
 
 #### Locally using pip
 - `cd tableau-utilities`

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.1.21",
+    version="2.1.22",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     long_description_content_type='text/markdown',
     name="tableau_utilities",
     version="2.1.22",
+    requires_python=">=3.8",
     packages=[
         'tableau_utilities',
         'tableau_utilities.general',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         'tableau_utilities.general',
         'tableau_utilities.tableau_file',
         'tableau_utilities.tableau_server',
-        'tableau_utilities.scripts'
+        'tableau_utilities.hyper',
+        'tableau_utilities.scripts',
     ],
     package_data={'tableau_utilities': ['tableau_file/*.yml']},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
                       'pandas>=1.4.1,<2.0.0',
                       'tabulate>=0.8.9,<1.0.0',
                       ],
-    extras_require={"HYPER": ['tableauhyperapi==0.0.18825']},
+    extras_require={"hyper": ['tableauhyperapi==0.0.18825']},
     entry_points={
         'console_scripts': [
             'tableau_utilities = tableau_utilities.scripts.cli:main',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
                       'requests>=2.27.1,<3.0.0',
                       'pandas>=1.4.1,<2.0.0',
                       'tabulate>=0.8.9,<1.0.0',
-                      'tableauhyperapi==0.0.18825'],
+                      ],
+    extras_require={"HYPER": ['tableauhyperapi==0.0.18825']},
     entry_points={
         'console_scripts': [
             'tableau_utilities = tableau_utilities.scripts.cli:main',

--- a/tableau_utilities/hyper/hyper.py
+++ b/tableau_utilities/hyper/hyper.py
@@ -1,0 +1,129 @@
+import os
+import shutil
+from zipfile import ZipFile
+from tableauhyperapi import HyperProcess, Connection, Telemetry, CreateMode, TableDefinition, TableName, SqlType
+
+from tableau_utilities.tableau_file.tableau_file import TableauFileError
+from tableau_utilities.tableau_file.tableau_file import Datasource
+
+class HyperFile:
+    """ The base class for a Tableau file, i.e. Datasource or Workbook. """
+
+    def __init__(self, file_path):
+        """
+        Args:
+            file_path (str): Path to a Tableau file
+
+        """
+        self.file_path = os.path.abspath(file_path)
+        self.file_directory = os.path.dirname(self.file_path)
+        self.file_basename = os.path.basename(self.file_path)
+        self.extension = file_path.split('.')[-1]
+        self.file_name = self.file_basename.replace(f'.{self.extension}', '')
+        # ''' Set on init '''
+        # self._tree: ET.ElementTree
+        # self._root: ET.Element
+        # self.has_extract_data: bool = False
+        # self.__extract_xml()
+
+    def empty_extract(self):
+        """ Creates an empty extract (.hyper file) for the Tableau file.
+            If the extract exists, it will be overwritten. """
+        # Get relevant paths, and create a temp folder and move the Tableau file into it
+        temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
+        extract_folder = os.path.join(temp_folder, 'Data', 'Extracts')
+        hyper_rel_path = os.path.join('Data', 'Extracts', f'{self.file_name}.hyper')
+        temp_path = os.path.join(temp_folder, self.file_basename)
+        tdsx_basename = f'{self.file_name}.tdsx'
+        tdsx_path = os.path.join(temp_folder, tdsx_basename)
+        os.makedirs(extract_folder, exist_ok=True)
+        shutil.move(self.file_path, temp_path)
+        if self.extension == 'tdsx':
+            # Unzip the TDS file
+            with ZipFile(temp_path) as z:
+                for f in z.filelist:
+                    ext = f.filename.split('.')[-1]
+                    if ext in ['tds', 'twb']:
+                        tds_path = z.extract(member=f, path=temp_folder)
+        else:
+            tds_path = temp_path
+        hyper_path = os.path.join(extract_folder, f'{self.file_name}.hyper')
+        params = {"default_database_version": "2"}
+        # Get columns from the metadata
+        columns = dict()  # Use a dict to ensure no duplicate columns are referenced
+        for metadata in self.connection.metadata_records:
+            if metadata.local_type == 'integer':
+                column = TableDefinition.Column(metadata.remote_name, SqlType.int())
+            elif metadata.local_type == 'real':
+                column = TableDefinition.Column(metadata.remote_name, SqlType.double())
+            elif metadata.local_type == 'string':
+                column = TableDefinition.Column(metadata.remote_name, SqlType.varchar(metadata.width or 1020))
+            elif metadata.local_type == 'boolean':
+                column = TableDefinition.Column(metadata.remote_name, SqlType.bool())
+            elif metadata.local_type == 'datetime':
+                column = TableDefinition.Column(metadata.remote_name, SqlType.timestamp())
+            elif metadata.local_type == 'date':
+                column = TableDefinition.Column(metadata.remote_name, SqlType.date())
+            else:
+                raise TableauFileError(f'Got unexpected metadata type for hyper table: {metadata.local_type}')
+            columns[metadata.remote_name] = column
+        # Create an empty .hyper file based on the metadata of the Tableau file
+        with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU, parameters=params) as hyper:
+            with Connection(hyper.endpoint, hyper_path, CreateMode.CREATE_AND_REPLACE) as connection:
+                # Create an `Extract` table inside an `Extract` schema
+                connection.catalog.create_schema('Extract')
+                table = TableDefinition(TableName('Extract', 'Extract'), columns.values())
+                connection.catalog.create_table(table)
+        # Archive the extract with the TDS file
+        with ZipFile(tdsx_path, 'w') as z:
+            z.write(tds_path, arcname=os.path.basename(tds_path))
+            z.write(hyper_path, arcname=hyper_rel_path)
+        # Update datasource extract to reference .hyper file
+        if self.extract:
+            self.extract.connection.class_name = 'hyper'
+            self.extract.connection.authentication = 'auth-none'
+            self.extract.connection.author_locale = 'en_US'
+            self.extract.connection.extract_engine = None
+            self.extract.connection.dbname = hyper_rel_path
+        # Move the tdsx out of the temp_folder and delete temp_folder
+        self.file_path = os.path.join(self.file_directory, tdsx_basename)
+        self.file_basename = tdsx_basename
+        self.extension = 'tdsx'
+        shutil.move(tdsx_path, self.file_path)
+        shutil.rmtree(temp_folder, ignore_errors=True)
+
+
+    def filter_extract(self, delete_condition: str):
+        """ Filters the data in the extract (.hyper file) for the Tableau file.
+
+        Args:
+            delete_condition (str): A condition string to add to the WHERE clause of data to delete.
+        """
+        if self.extension != 'tdsx' or not self.has_extract_data:
+            return None
+        # Get relevant paths, and create a temp folder and move the Tableau file into it
+        temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
+        temp_path = os.path.join(temp_folder, self.file_basename)
+        os.makedirs(temp_folder, exist_ok=True)
+        shutil.move(self.file_path, temp_path)
+        # Unzip the TDS file
+        unzipped_files = list()
+        with ZipFile(temp_path) as z:
+            for f in z.filelist:
+                ext = f.filename.split('.')[-1]
+                path = z.extract(member=f, path=temp_folder)
+                unzipped_files.append(path)
+                if ext == 'hyper':
+                    hyper_path = path
+        # Update .hyper file based on the filter condition
+        with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU) as hyper:
+            with Connection(hyper.endpoint, hyper_path, CreateMode.NONE) as connection:
+                connection.execute_command(f'DELETE FROM "Extract"."Extract" WHERE {delete_condition}')
+        # Archive the extract with the TDS file
+        with ZipFile(temp_path, 'w') as z:
+            for file in unzipped_files:
+                arcname = file.split(temp_folder)[-1]
+                z.write(file, arcname=arcname)
+        # Move the tdsx out of the temp_folder and delete temp_folder
+        shutil.move(temp_path, self.file_path)
+        shutil.rmtree(temp_folder, ignore_errors=True)

--- a/tableau_utilities/hyper/hyper.py
+++ b/tableau_utilities/hyper/hyper.py
@@ -4,126 +4,112 @@ from zipfile import ZipFile
 from tableauhyperapi import HyperProcess, Connection, Telemetry, CreateMode, TableDefinition, TableName, SqlType
 
 from tableau_utilities.tableau_file.tableau_file import TableauFileError
-from tableau_utilities.tableau_file.tableau_file import Datasource
-
-class HyperFile:
-    """ The base class for a Tableau file, i.e. Datasource or Workbook. """
-
-    def __init__(self, file_path):
-        """
-        Args:
-            file_path (str): Path to a Tableau file
-
-        """
-        self.file_path = os.path.abspath(file_path)
-        self.file_directory = os.path.dirname(self.file_path)
-        self.file_basename = os.path.basename(self.file_path)
-        self.extension = file_path.split('.')[-1]
-        self.file_name = self.file_basename.replace(f'.{self.extension}', '')
-        # ''' Set on init '''
-        # self._tree: ET.ElementTree
-        # self._root: ET.Element
-        # self.has_extract_data: bool = False
-        # self.__extract_xml()
-
-    def empty_extract(self):
-        """ Creates an empty extract (.hyper file) for the Tableau file.
-            If the extract exists, it will be overwritten. """
-        # Get relevant paths, and create a temp folder and move the Tableau file into it
-        temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
-        extract_folder = os.path.join(temp_folder, 'Data', 'Extracts')
-        hyper_rel_path = os.path.join('Data', 'Extracts', f'{self.file_name}.hyper')
-        temp_path = os.path.join(temp_folder, self.file_basename)
-        tdsx_basename = f'{self.file_name}.tdsx'
-        tdsx_path = os.path.join(temp_folder, tdsx_basename)
-        os.makedirs(extract_folder, exist_ok=True)
-        shutil.move(self.file_path, temp_path)
-        if self.extension == 'tdsx':
-            # Unzip the TDS file
-            with ZipFile(temp_path) as z:
-                for f in z.filelist:
-                    ext = f.filename.split('.')[-1]
-                    if ext in ['tds', 'twb']:
-                        tds_path = z.extract(member=f, path=temp_folder)
-        else:
-            tds_path = temp_path
-        hyper_path = os.path.join(extract_folder, f'{self.file_name}.hyper')
-        params = {"default_database_version": "2"}
-        # Get columns from the metadata
-        columns = dict()  # Use a dict to ensure no duplicate columns are referenced
-        for metadata in self.connection.metadata_records:
-            if metadata.local_type == 'integer':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.int())
-            elif metadata.local_type == 'real':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.double())
-            elif metadata.local_type == 'string':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.varchar(metadata.width or 1020))
-            elif metadata.local_type == 'boolean':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.bool())
-            elif metadata.local_type == 'datetime':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.timestamp())
-            elif metadata.local_type == 'date':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.date())
-            else:
-                raise TableauFileError(f'Got unexpected metadata type for hyper table: {metadata.local_type}')
-            columns[metadata.remote_name] = column
-        # Create an empty .hyper file based on the metadata of the Tableau file
-        with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU, parameters=params) as hyper:
-            with Connection(hyper.endpoint, hyper_path, CreateMode.CREATE_AND_REPLACE) as connection:
-                # Create an `Extract` table inside an `Extract` schema
-                connection.catalog.create_schema('Extract')
-                table = TableDefinition(TableName('Extract', 'Extract'), columns.values())
-                connection.catalog.create_table(table)
-        # Archive the extract with the TDS file
-        with ZipFile(tdsx_path, 'w') as z:
-            z.write(tds_path, arcname=os.path.basename(tds_path))
-            z.write(hyper_path, arcname=hyper_rel_path)
-        # Update datasource extract to reference .hyper file
-        if self.extract:
-            self.extract.connection.class_name = 'hyper'
-            self.extract.connection.authentication = 'auth-none'
-            self.extract.connection.author_locale = 'en_US'
-            self.extract.connection.extract_engine = None
-            self.extract.connection.dbname = hyper_rel_path
-        # Move the tdsx out of the temp_folder and delete temp_folder
-        self.file_path = os.path.join(self.file_directory, tdsx_basename)
-        self.file_basename = tdsx_basename
-        self.extension = 'tdsx'
-        shutil.move(tdsx_path, self.file_path)
-        shutil.rmtree(temp_folder, ignore_errors=True)
 
 
-    def filter_extract(self, delete_condition: str):
-        """ Filters the data in the extract (.hyper file) for the Tableau file.
+def empty_extract(Datasource):
+    """ Creates an empty extract (.hyper file) for the Tableau file.
+        If the extract exists, it will be overwritten.
 
         Args:
-            delete_condition (str): A condition string to add to the WHERE clause of data to delete.
-        """
-        if self.extension != 'tdsx' or not self.has_extract_data:
-            return None
-        # Get relevant paths, and create a temp folder and move the Tableau file into it
-        temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
-        temp_path = os.path.join(temp_folder, self.file_basename)
-        os.makedirs(temp_folder, exist_ok=True)
-        shutil.move(self.file_path, temp_path)
+            Datasource: The tableau_utilities datasource class
+
+    """
+    # Get relevant paths, and create a temp folder and move the Tableau file into it
+    temp_folder = os.path.join(Datasource.file_directory, f'__TEMP_{Datasource.file_name}')
+    extract_folder = os.path.join(temp_folder, 'Data', 'Extracts')
+    hyper_rel_path = os.path.join('Data', 'Extracts', f'{Datasource.file_name}.hyper')
+    temp_path = os.path.join(temp_folder, Datasource.file_basename)
+    tdsx_basename = f'{Datasource.file_name}.tdsx'
+    tdsx_path = os.path.join(temp_folder, tdsx_basename)
+    os.makedirs(extract_folder, exist_ok=True)
+    shutil.move(Datasource.file_path, temp_path)
+    if Datasource.extension == 'tdsx':
         # Unzip the TDS file
-        unzipped_files = list()
         with ZipFile(temp_path) as z:
             for f in z.filelist:
                 ext = f.filename.split('.')[-1]
-                path = z.extract(member=f, path=temp_folder)
-                unzipped_files.append(path)
-                if ext == 'hyper':
-                    hyper_path = path
-        # Update .hyper file based on the filter condition
-        with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU) as hyper:
-            with Connection(hyper.endpoint, hyper_path, CreateMode.NONE) as connection:
-                connection.execute_command(f'DELETE FROM "Extract"."Extract" WHERE {delete_condition}')
-        # Archive the extract with the TDS file
-        with ZipFile(temp_path, 'w') as z:
-            for file in unzipped_files:
-                arcname = file.split(temp_folder)[-1]
-                z.write(file, arcname=arcname)
-        # Move the tdsx out of the temp_folder and delete temp_folder
-        shutil.move(temp_path, self.file_path)
-        shutil.rmtree(temp_folder, ignore_errors=True)
+                if ext in ['tds', 'twb']:
+                    tds_path = z.extract(member=f, path=temp_folder)
+    else:
+        tds_path = temp_path
+    hyper_path = os.path.join(extract_folder, f'{Datasource.file_name}.hyper')
+    params = {"default_database_version": "2"}
+    # Get columns from the metadata
+    columns = dict()  # Use a dict to ensure no duplicate columns are referenced
+    for metadata in Datasource.connection.metadata_records:
+        if metadata.local_type == 'integer':
+            column = TableDefinition.Column(metadata.remote_name, SqlType.int())
+        elif metadata.local_type == 'real':
+            column = TableDefinition.Column(metadata.remote_name, SqlType.double())
+        elif metadata.local_type == 'string':
+            column = TableDefinition.Column(metadata.remote_name, SqlType.varchar(metadata.width or 1020))
+        elif metadata.local_type == 'boolean':
+            column = TableDefinition.Column(metadata.remote_name, SqlType.bool())
+        elif metadata.local_type == 'datetime':
+            column = TableDefinition.Column(metadata.remote_name, SqlType.timestamp())
+        elif metadata.local_type == 'date':
+            column = TableDefinition.Column(metadata.remote_name, SqlType.date())
+        else:
+            raise TableauFileError(f'Got unexpected metadata type for hyper table: {metadata.local_type}')
+        columns[metadata.remote_name] = column
+    # Create an empty .hyper file based on the metadata of the Tableau file
+    with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU, parameters=params) as hyper:
+        with Connection(hyper.endpoint, hyper_path, CreateMode.CREATE_AND_REPLACE) as connection:
+            # Create an `Extract` table inside an `Extract` schema
+            connection.catalog.create_schema('Extract')
+            table = TableDefinition(TableName('Extract', 'Extract'), columns.values())
+            connection.catalog.create_table(table)
+    # Archive the extract with the TDS file
+    with ZipFile(tdsx_path, 'w') as z:
+        z.write(tds_path, arcname=os.path.basename(tds_path))
+        z.write(hyper_path, arcname=hyper_rel_path)
+    # Update datasource extract to reference .hyper file
+    if Datasource.extract:
+        Datasource.extract.connection.class_name = 'hyper'
+        Datasource.extract.connection.authentication = 'auth-none'
+        Datasource.extract.connection.author_locale = 'en_US'
+        Datasource.extract.connection.extract_engine = None
+        Datasource.extract.connection.dbname = hyper_rel_path
+    # Move the tdsx out of the temp_folder and delete temp_folder
+    Datasource.file_path = os.path.join(Datasource.file_directory, tdsx_basename)
+    Datasource.file_basename = tdsx_basename
+    Datasource.extension = 'tdsx'
+    shutil.move(tdsx_path, Datasource.file_path)
+    shutil.rmtree(temp_folder, ignore_errors=True)
+
+
+def filter_extract(Datasource, delete_condition):
+    """ Filters the data in the extract (.hyper file) for the Tableau file.
+
+    Args:
+        Datasource: The tableau_utilities datasource class
+        delete_condition (str): A condition string to add to the WHERE clause of data to delete.
+    """
+    if Datasource.extension != 'tdsx' or not Datasource.has_extract_data:
+        return None
+    # Get relevant paths, and create a temp folder and move the Tableau file into it
+    temp_folder = os.path.join(Datasource.file_directory, f'__TEMP_{Datasource.file_name}')
+    temp_path = os.path.join(temp_folder, Datasource.file_basename)
+    os.makedirs(temp_folder, exist_ok=True)
+    shutil.move(Datasource.file_path, temp_path)
+    # Unzip the TDS file
+    unzipped_files = list()
+    with ZipFile(temp_path) as z:
+        for f in z.filelist:
+            ext = f.filename.split('.')[-1]
+            path = z.extract(member=f, path=temp_folder)
+            unzipped_files.append(path)
+            if ext == 'hyper':
+                hyper_path = path
+    # Update .hyper file based on the filter condition
+    with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU) as hyper:
+        with Connection(hyper.endpoint, hyper_path, CreateMode.NONE) as connection:
+            connection.execute_command(f'DELETE FROM "Extract"."Extract" WHERE {delete_condition}')
+    # Archive the extract with the TDS file
+    with ZipFile(temp_path, 'w') as z:
+        for file in unzipped_files:
+            arcname = file.split(temp_folder)[-1]
+            z.write(file, arcname=arcname)
+    # Move the tdsx out of the temp_folder and delete temp_folder
+    shutil.move(temp_path, Datasource.file_path)
+    shutil.rmtree(temp_folder, ignore_errors=True)

--- a/tableau_utilities/scripts/cli.py
+++ b/tableau_utilities/scripts/cli.py
@@ -275,8 +275,6 @@ def validate_subpackage_hyper():
             '--filter_extract and --empty_extract require the tableau_utilities[hyper] subpackage.  See installation notes if you are on an Apple Silicon (Apple M1, Apple M2, ...)')
 
 
-
-
 def tableau_authentication(args):
     """ Creates the Tableau server authentication from a variety of methods for passing in credentials """
     debug = args.debugging_logs

--- a/tableau_utilities/scripts/cli.py
+++ b/tableau_utilities/scripts/cli.py
@@ -3,7 +3,9 @@ import os
 import shutil
 from argparse import RawTextHelpFormatter
 import yaml
+import pkg_resources
 import pkgutil
+import importlib.metadata
 
 import tableau_utilities.tableau_server.tableau_server as ts
 
@@ -16,7 +18,8 @@ from tableau_utilities.scripts.server_operate import server_operate
 from tableau_utilities.scripts.datasource import datasource
 from tableau_utilities.scripts.csv_config import csv_config
 
-__version__ = pkgutil.get_importer("tableau_utilities").find_module("tableau_utilities").load_module().__version__
+# __version__ = pkgutil.get_importer("tableau_utilities").find_module("tableau_utilities").load_module().__version__
+__version__ = pkg_resources.require("tableau_utilities")[0].version
 
 parser = argparse.ArgumentParser(
     prog='tableau_utilities',
@@ -265,11 +268,13 @@ def validate_args_command_merge_config(args):
 def validate_subpackage_hyper():
     """ Checks that the hyper subpackage is installed for functions that use it """
 
-    if pkgutil.find_loader('numpy') is not None:
-        pass
-    else:
+    try:
+        version = importlib.metadata.version("tableauhyperapi")
+    except importlib.metadata.PackageNotFoundError:
         parser.error(
             '--filter_extract and --empty_extract require the tableau_utilities[hyper] subpackage.  See installation notes if you are on an Apple Silicon (Apple M1, Apple M2, ...)')
+
+
 
 
 def tableau_authentication(args):

--- a/tableau_utilities/scripts/cli.py
+++ b/tableau_utilities/scripts/cli.py
@@ -472,7 +472,7 @@ def main():
         args.command == 'datasource' and (args.empty_extract or args.filter_extract)
     )
 
-    needs_tableau_server = (echo $TABLEAU_PAT_VALUE
+    needs_tableau_server = (
         (args.command == 'generate_config' and args.location == 'online')
         or (args.command == 'merge_config' and args.location == 'online')
         or (args.command == 'datasource' and args.location == 'online')

--- a/tableau_utilities/scripts/cli.py
+++ b/tableau_utilities/scripts/cli.py
@@ -160,9 +160,9 @@ parser_datasource.add_argument('--persona', choices=list(personas.keys()),
                                help='The datatype persona of the column. Required for adding a new column')
 parser_datasource.add_argument('--desc', help='A Tableau column description')
 parser_datasource.add_argument('--calculation', help='A Tableau calculation')
-parser_datasource.add_argument('-E', '--empty_extract', action='store_true',
+parser_datasource.add_argument('-ee', '--empty_extract', action='store_true',
                                help='Adds an empty extract to the Datasource if specified.')
-parser_datasource.add_argument('-F', '--filter_extract',
+parser_datasource.add_argument('-fe', '--filter_extract',
                                help='Deletes data from the extract based on the condition string provided. '
                                     """E.g. "CREATED_AT" < '1/1/2024'""")
 parser_datasource.set_defaults(func=datasource)

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 import os
 import shutil
 import xmltodict
-from tableauhyperapi import HyperProcess, Connection, Telemetry, CreateMode, TableDefinition, TableName, SqlType
+# from tableauhyperapi import HyperProcess, Connection, Telemetry, CreateMode, TableDefinition, TableName, SqlType
 from zipfile import ZipFile
 
 import tableau_utilities.tableau_file.tableau_file_objects as tfo
@@ -301,107 +301,107 @@ class Datasource(TableauFile):
             # Otherwise, Add Extract MappingCol
             if not found:
                 self.extract.connection.cols.append(extract_col)
-
-    def empty_extract(self):
-        """ Creates an empty extract (.hyper file) for the Tableau file.
-            If the extract exists, it will be overwritten. """
-        # Get relevant paths, and create a temp folder and move the Tableau file into it
-        temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
-        extract_folder = os.path.join(temp_folder, 'Data', 'Extracts')
-        hyper_rel_path = os.path.join('Data', 'Extracts', f'{self.file_name}.hyper')
-        temp_path = os.path.join(temp_folder, self.file_basename)
-        tdsx_basename = f'{self.file_name}.tdsx'
-        tdsx_path = os.path.join(temp_folder, tdsx_basename)
-        os.makedirs(extract_folder, exist_ok=True)
-        shutil.move(self.file_path, temp_path)
-        if self.extension == 'tdsx':
-            # Unzip the TDS file
-            with ZipFile(temp_path) as z:
-                for f in z.filelist:
-                    ext = f.filename.split('.')[-1]
-                    if ext in ['tds', 'twb']:
-                        tds_path = z.extract(member=f, path=temp_folder)
-        else:
-            tds_path = temp_path
-        hyper_path = os.path.join(extract_folder, f'{self.file_name}.hyper')
-        params = {"default_database_version": "2"}
-        # Get columns from the metadata
-        columns = dict()  # Use a dict to ensure no duplicate columns are referenced
-        for metadata in self.connection.metadata_records:
-            if metadata.local_type == 'integer':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.int())
-            elif metadata.local_type == 'real':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.double())
-            elif metadata.local_type == 'string':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.varchar(metadata.width or 1020))
-            elif metadata.local_type == 'boolean':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.bool())
-            elif metadata.local_type == 'datetime':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.timestamp())
-            elif metadata.local_type == 'date':
-                column = TableDefinition.Column(metadata.remote_name, SqlType.date())
-            else:
-                raise TableauFileError(f'Got unexpected metadata type for hyper table: {metadata.local_type}')
-            columns[metadata.remote_name] = column
-        # Create an empty .hyper file based on the metadata of the Tableau file
-        with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU, parameters=params) as hyper:
-            with Connection(hyper.endpoint, hyper_path, CreateMode.CREATE_AND_REPLACE) as connection:
-                # Create an `Extract` table inside an `Extract` schema
-                connection.catalog.create_schema('Extract')
-                table = TableDefinition(TableName('Extract', 'Extract'), columns.values())
-                connection.catalog.create_table(table)
-        # Archive the extract with the TDS file
-        with ZipFile(tdsx_path, 'w') as z:
-            z.write(tds_path, arcname=os.path.basename(tds_path))
-            z.write(hyper_path, arcname=hyper_rel_path)
-        # Update datasource extract to reference .hyper file
-        if self.extract:
-            self.extract.connection.class_name = 'hyper'
-            self.extract.connection.authentication = 'auth-none'
-            self.extract.connection.author_locale = 'en_US'
-            self.extract.connection.extract_engine = None
-            self.extract.connection.dbname = hyper_rel_path
-        # Move the tdsx out of the temp_folder and delete temp_folder
-        self.file_path = os.path.join(self.file_directory, tdsx_basename)
-        self.file_basename = tdsx_basename
-        self.extension = 'tdsx'
-        shutil.move(tdsx_path, self.file_path)
-        shutil.rmtree(temp_folder, ignore_errors=True)
-
-    def filter_extract(self, delete_condition: str):
-        """ Filters the data in the extract (.hyper file) for the Tableau file.
-
-        Args:
-            delete_condition (str): A condition string to add to the WHERE clause of data to delete.
-        """
-        if self.extension != 'tdsx' or not self.has_extract_data:
-            return None
-        # Get relevant paths, and create a temp folder and move the Tableau file into it
-        temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
-        temp_path = os.path.join(temp_folder, self.file_basename)
-        os.makedirs(temp_folder, exist_ok=True)
-        shutil.move(self.file_path, temp_path)
-        # Unzip the TDS file
-        unzipped_files = list()
-        with ZipFile(temp_path) as z:
-            for f in z.filelist:
-                ext = f.filename.split('.')[-1]
-                path = z.extract(member=f, path=temp_folder)
-                unzipped_files.append(path)
-                if ext == 'hyper':
-                    hyper_path = path
-        # Update .hyper file based on the filter condition
-        with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU) as hyper:
-            with Connection(hyper.endpoint, hyper_path, CreateMode.NONE) as connection:
-                connection.execute_command(f'DELETE FROM "Extract"."Extract" WHERE {delete_condition}')
-        # Archive the extract with the TDS file
-        with ZipFile(temp_path, 'w') as z:
-            for file in unzipped_files:
-                arcname = file.split(temp_folder)[-1]
-                z.write(file, arcname=arcname)
-        # Move the tdsx out of the temp_folder and delete temp_folder
-        shutil.move(temp_path, self.file_path)
-        shutil.rmtree(temp_folder, ignore_errors=True)
+    #
+    # def empty_extract(self):
+    #     """ Creates an empty extract (.hyper file) for the Tableau file.
+    #         If the extract exists, it will be overwritten. """
+    #     # Get relevant paths, and create a temp folder and move the Tableau file into it
+    #     temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
+    #     extract_folder = os.path.join(temp_folder, 'Data', 'Extracts')
+    #     hyper_rel_path = os.path.join('Data', 'Extracts', f'{self.file_name}.hyper')
+    #     temp_path = os.path.join(temp_folder, self.file_basename)
+    #     tdsx_basename = f'{self.file_name}.tdsx'
+    #     tdsx_path = os.path.join(temp_folder, tdsx_basename)
+    #     os.makedirs(extract_folder, exist_ok=True)
+    #     shutil.move(self.file_path, temp_path)
+    #     if self.extension == 'tdsx':
+    #         # Unzip the TDS file
+    #         with ZipFile(temp_path) as z:
+    #             for f in z.filelist:
+    #                 ext = f.filename.split('.')[-1]
+    #                 if ext in ['tds', 'twb']:
+    #                     tds_path = z.extract(member=f, path=temp_folder)
+    #     else:
+    #         tds_path = temp_path
+    #     hyper_path = os.path.join(extract_folder, f'{self.file_name}.hyper')
+    #     params = {"default_database_version": "2"}
+    #     # Get columns from the metadata
+    #     columns = dict()  # Use a dict to ensure no duplicate columns are referenced
+    #     for metadata in self.connection.metadata_records:
+    #         if metadata.local_type == 'integer':
+    #             column = TableDefinition.Column(metadata.remote_name, SqlType.int())
+    #         elif metadata.local_type == 'real':
+    #             column = TableDefinition.Column(metadata.remote_name, SqlType.double())
+    #         elif metadata.local_type == 'string':
+    #             column = TableDefinition.Column(metadata.remote_name, SqlType.varchar(metadata.width or 1020))
+    #         elif metadata.local_type == 'boolean':
+    #             column = TableDefinition.Column(metadata.remote_name, SqlType.bool())
+    #         elif metadata.local_type == 'datetime':
+    #             column = TableDefinition.Column(metadata.remote_name, SqlType.timestamp())
+    #         elif metadata.local_type == 'date':
+    #             column = TableDefinition.Column(metadata.remote_name, SqlType.date())
+    #         else:
+    #             raise TableauFileError(f'Got unexpected metadata type for hyper table: {metadata.local_type}')
+    #         columns[metadata.remote_name] = column
+    #     # Create an empty .hyper file based on the metadata of the Tableau file
+    #     with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU, parameters=params) as hyper:
+    #         with Connection(hyper.endpoint, hyper_path, CreateMode.CREATE_AND_REPLACE) as connection:
+    #             # Create an `Extract` table inside an `Extract` schema
+    #             connection.catalog.create_schema('Extract')
+    #             table = TableDefinition(TableName('Extract', 'Extract'), columns.values())
+    #             connection.catalog.create_table(table)
+    #     # Archive the extract with the TDS file
+    #     with ZipFile(tdsx_path, 'w') as z:
+    #         z.write(tds_path, arcname=os.path.basename(tds_path))
+    #         z.write(hyper_path, arcname=hyper_rel_path)
+    #     # Update datasource extract to reference .hyper file
+    #     if self.extract:
+    #         self.extract.connection.class_name = 'hyper'
+    #         self.extract.connection.authentication = 'auth-none'
+    #         self.extract.connection.author_locale = 'en_US'
+    #         self.extract.connection.extract_engine = None
+    #         self.extract.connection.dbname = hyper_rel_path
+    #     # Move the tdsx out of the temp_folder and delete temp_folder
+    #     self.file_path = os.path.join(self.file_directory, tdsx_basename)
+    #     self.file_basename = tdsx_basename
+    #     self.extension = 'tdsx'
+    #     shutil.move(tdsx_path, self.file_path)
+    #     shutil.rmtree(temp_folder, ignore_errors=True)
+    #
+    # def filter_extract(self, delete_condition: str):
+    #     """ Filters the data in the extract (.hyper file) for the Tableau file.
+    #
+    #     Args:
+    #         delete_condition (str): A condition string to add to the WHERE clause of data to delete.
+    #     """
+    #     if self.extension != 'tdsx' or not self.has_extract_data:
+    #         return None
+    #     # Get relevant paths, and create a temp folder and move the Tableau file into it
+    #     temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
+    #     temp_path = os.path.join(temp_folder, self.file_basename)
+    #     os.makedirs(temp_folder, exist_ok=True)
+    #     shutil.move(self.file_path, temp_path)
+    #     # Unzip the TDS file
+    #     unzipped_files = list()
+    #     with ZipFile(temp_path) as z:
+    #         for f in z.filelist:
+    #             ext = f.filename.split('.')[-1]
+    #             path = z.extract(member=f, path=temp_folder)
+    #             unzipped_files.append(path)
+    #             if ext == 'hyper':
+    #                 hyper_path = path
+    #     # Update .hyper file based on the filter condition
+    #     with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU) as hyper:
+    #         with Connection(hyper.endpoint, hyper_path, CreateMode.NONE) as connection:
+    #             connection.execute_command(f'DELETE FROM "Extract"."Extract" WHERE {delete_condition}')
+    #     # Archive the extract with the TDS file
+    #     with ZipFile(temp_path, 'w') as z:
+    #         for file in unzipped_files:
+    #             arcname = file.split(temp_folder)[-1]
+    #             z.write(file, arcname=arcname)
+    #     # Move the tdsx out of the temp_folder and delete temp_folder
+    #     shutil.move(temp_path, self.file_path)
+    #     shutil.rmtree(temp_folder, ignore_errors=True)
 
     def save(self):
         """ Save all changes made to each section of the Datasource """

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -3,7 +3,6 @@ import xml.etree.ElementTree as ET
 import os
 import shutil
 import xmltodict
-# from tableauhyperapi import HyperProcess, Connection, Telemetry, CreateMode, TableDefinition, TableName, SqlType
 from zipfile import ZipFile
 
 import tableau_utilities.tableau_file.tableau_file_objects as tfo
@@ -301,107 +300,6 @@ class Datasource(TableauFile):
             # Otherwise, Add Extract MappingCol
             if not found:
                 self.extract.connection.cols.append(extract_col)
-    #
-    # def empty_extract(self):
-    #     """ Creates an empty extract (.hyper file) for the Tableau file.
-    #         If the extract exists, it will be overwritten. """
-    #     # Get relevant paths, and create a temp folder and move the Tableau file into it
-    #     temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
-    #     extract_folder = os.path.join(temp_folder, 'Data', 'Extracts')
-    #     hyper_rel_path = os.path.join('Data', 'Extracts', f'{self.file_name}.hyper')
-    #     temp_path = os.path.join(temp_folder, self.file_basename)
-    #     tdsx_basename = f'{self.file_name}.tdsx'
-    #     tdsx_path = os.path.join(temp_folder, tdsx_basename)
-    #     os.makedirs(extract_folder, exist_ok=True)
-    #     shutil.move(self.file_path, temp_path)
-    #     if self.extension == 'tdsx':
-    #         # Unzip the TDS file
-    #         with ZipFile(temp_path) as z:
-    #             for f in z.filelist:
-    #                 ext = f.filename.split('.')[-1]
-    #                 if ext in ['tds', 'twb']:
-    #                     tds_path = z.extract(member=f, path=temp_folder)
-    #     else:
-    #         tds_path = temp_path
-    #     hyper_path = os.path.join(extract_folder, f'{self.file_name}.hyper')
-    #     params = {"default_database_version": "2"}
-    #     # Get columns from the metadata
-    #     columns = dict()  # Use a dict to ensure no duplicate columns are referenced
-    #     for metadata in self.connection.metadata_records:
-    #         if metadata.local_type == 'integer':
-    #             column = TableDefinition.Column(metadata.remote_name, SqlType.int())
-    #         elif metadata.local_type == 'real':
-    #             column = TableDefinition.Column(metadata.remote_name, SqlType.double())
-    #         elif metadata.local_type == 'string':
-    #             column = TableDefinition.Column(metadata.remote_name, SqlType.varchar(metadata.width or 1020))
-    #         elif metadata.local_type == 'boolean':
-    #             column = TableDefinition.Column(metadata.remote_name, SqlType.bool())
-    #         elif metadata.local_type == 'datetime':
-    #             column = TableDefinition.Column(metadata.remote_name, SqlType.timestamp())
-    #         elif metadata.local_type == 'date':
-    #             column = TableDefinition.Column(metadata.remote_name, SqlType.date())
-    #         else:
-    #             raise TableauFileError(f'Got unexpected metadata type for hyper table: {metadata.local_type}')
-    #         columns[metadata.remote_name] = column
-    #     # Create an empty .hyper file based on the metadata of the Tableau file
-    #     with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU, parameters=params) as hyper:
-    #         with Connection(hyper.endpoint, hyper_path, CreateMode.CREATE_AND_REPLACE) as connection:
-    #             # Create an `Extract` table inside an `Extract` schema
-    #             connection.catalog.create_schema('Extract')
-    #             table = TableDefinition(TableName('Extract', 'Extract'), columns.values())
-    #             connection.catalog.create_table(table)
-    #     # Archive the extract with the TDS file
-    #     with ZipFile(tdsx_path, 'w') as z:
-    #         z.write(tds_path, arcname=os.path.basename(tds_path))
-    #         z.write(hyper_path, arcname=hyper_rel_path)
-    #     # Update datasource extract to reference .hyper file
-    #     if self.extract:
-    #         self.extract.connection.class_name = 'hyper'
-    #         self.extract.connection.authentication = 'auth-none'
-    #         self.extract.connection.author_locale = 'en_US'
-    #         self.extract.connection.extract_engine = None
-    #         self.extract.connection.dbname = hyper_rel_path
-    #     # Move the tdsx out of the temp_folder and delete temp_folder
-    #     self.file_path = os.path.join(self.file_directory, tdsx_basename)
-    #     self.file_basename = tdsx_basename
-    #     self.extension = 'tdsx'
-    #     shutil.move(tdsx_path, self.file_path)
-    #     shutil.rmtree(temp_folder, ignore_errors=True)
-    #
-    # def filter_extract(self, delete_condition: str):
-    #     """ Filters the data in the extract (.hyper file) for the Tableau file.
-    #
-    #     Args:
-    #         delete_condition (str): A condition string to add to the WHERE clause of data to delete.
-    #     """
-    #     if self.extension != 'tdsx' or not self.has_extract_data:
-    #         return None
-    #     # Get relevant paths, and create a temp folder and move the Tableau file into it
-    #     temp_folder = os.path.join(self.file_directory, f'__TEMP_{self.file_name}')
-    #     temp_path = os.path.join(temp_folder, self.file_basename)
-    #     os.makedirs(temp_folder, exist_ok=True)
-    #     shutil.move(self.file_path, temp_path)
-    #     # Unzip the TDS file
-    #     unzipped_files = list()
-    #     with ZipFile(temp_path) as z:
-    #         for f in z.filelist:
-    #             ext = f.filename.split('.')[-1]
-    #             path = z.extract(member=f, path=temp_folder)
-    #             unzipped_files.append(path)
-    #             if ext == 'hyper':
-    #                 hyper_path = path
-    #     # Update .hyper file based on the filter condition
-    #     with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU) as hyper:
-    #         with Connection(hyper.endpoint, hyper_path, CreateMode.NONE) as connection:
-    #             connection.execute_command(f'DELETE FROM "Extract"."Extract" WHERE {delete_condition}')
-    #     # Archive the extract with the TDS file
-    #     with ZipFile(temp_path, 'w') as z:
-    #         for file in unzipped_files:
-    #             arcname = file.split(temp_folder)[-1]
-    #             z.write(file, arcname=arcname)
-    #     # Move the tdsx out of the temp_folder and delete temp_folder
-    #     shutil.move(temp_path, self.file_path)
-    #     shutil.rmtree(temp_folder, ignore_errors=True)
 
     def save(self):
         """ Save all changes made to each section of the Datasource """


### PR DESCRIPTION
@JustinGrilli  I think this might be a better way to go than the other PR.  This is a rough draft but here's the general idea:

Python will let you configure packages with extras. So the pip install commands are like this:

`pip install my_package`
`pip install my_package[extra]`

In this case we can move the hyper code to it's own package and then specify to only install the `tableauhyperapi` when the extra is specified.  I ran these commands:

`pip install ./`  this installed the tableau_utilities but did not install the `tableauhyperapi` dependency
`pip install ./[hyper]` this DID install the `tableauhyperapi` dependency

So in this approach we just have a small amount of refactoring to do.  I'm trying to get `twine` to work so I can upload the packages to pypi test and try installing on my Apple Silicon mac but I'm having environment problems on this old laptop.

Let me know what you think of this approach.