### PR TITLE
Move imports to IF statement to avoid error when installing on Apple …

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ tableau_utilities --token_name my_token_name --token_secret 1q2w3e4r5t6y7u8i9o -
 
 Generate a config from a local file. Add a file prefix and print the debugging logs to the console
 ```commandline
-tableau_utilities --debugging_logs generate_config --location local --file_path '/code/tableau-utilities/tmp_tdsx_and_config/My Awesome Datasource.tdsx' --file_prefix
+tableau_utilities --debugging_logs  --location local --file_path '/code/tableau-utilities/tmp_tdsx_and_config/My Awesome Datasource.tdsx' generate_config --file_prefix
 ```
 
 #### csv_config

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.2.0",
+    version="2.2.11",
     requires_python=">=3.8",
     packages=[
         'tableau_utilities',

--- a/tableau_utilities/scripts/datasource.py
+++ b/tableau_utilities/scripts/datasource.py
@@ -9,7 +9,6 @@ from tableau_utilities.general.cli_styling import Color
 from tableau_utilities.general.cli_styling import Symbol
 from tableau_utilities.tableau_file.tableau_file import Datasource
 from tableau_utilities.tableau_server.tableau_server import TableauServer
-from tableau_utilities.hyper.hyper import create_empty_hyper_extract, filter_hyper_extract
 
 
 def datasource(args, server=None):
@@ -74,10 +73,12 @@ def datasource(args, server=None):
 
     # Add an empty .hyper file to the Datasource; Useful for publishing without data
     if empty_extract:
+        from tableau_utilities.hyper.hyper import create_empty_hyper_extract
         create_empty_hyper_extract(ds)
         print(f'{color.fg_green}Added empty .hyper extract for {datasource_path}{color.reset}')
     # Otherwise, filter the extract if filter_extract string provided
     elif filter_extract:
+        from tableau_utilities.hyper.hyper import filter_hyper_extract
         start = time()
         print(f'{color.fg_cyan}...Filtering extract data...{color.reset}')
         filter_hyper_extract(ds, filter_extract)


### PR DESCRIPTION
# Background

The published package was still having trouble installing on an M1 due to the tableauhyperapi dependency.  While the installation had worked when I installed using `./` installing from pip didn't seem to work.

# Changes
* Moves imports to inside an IF statement in the cli
* Fixes error in docs for cli
* For some reason I couldn't name this 2.0.01 once I had created 2.0.1 in my test pypi so I went straight to 2.0.11.

# Testing
I pushed this package to PyPi Test to make sure I really had it fixed this time.

## Installs from Pypi Test
```
➜  ~ pip install -i https://test.pypi.org/simple/ tableau-utilities
Looking in indexes: https://test.pypi.org/simple/
Collecting tableau-utilities
  Downloading https://test-files.pythonhosted.org/packages/8d/ed/d13473417a2e2f06ff049a6d789bebdfd66432fda3568b5cff783a8cc29b/tableau_utilities-2.2.11-py3-none-any.whl.metadata (9.1 kB)
Requirement already satisfied: xmltodict<1.0.0,>=0.12.0 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities) (0.13.0)
Requirement already satisfied: pyyaml<7.0.0,>=6.0 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities) (6.0.1)
Requirement already satisfied: requests<3.0.0,>=2.27.1 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities) (2.31.0)
Requirement already satisfied: pandas<2.0.0,>=1.4.1 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities) (1.5.3)
Requirement already satisfied: tabulate<1.0.0,>=0.8.9 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities) (0.9.0)
Requirement already satisfied: python-dateutil>=2.8.1 in /opt/homebrew/lib/python3.12/site-packages (from pandas<2.0.0,>=1.4.1->tableau-utilities) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in /opt/homebrew/lib/python3.12/site-packages (from pandas<2.0.0,>=1.4.1->tableau-utilities) (2024.1)
Requirement already satisfied: numpy>=1.21.0 in /opt/homebrew/lib/python3.12/site-packages (from pandas<2.0.0,>=1.4.1->tableau-utilities) (1.26.4)
Requirement already satisfied: charset-normalizer<4,>=2 in /opt/homebrew/lib/python3.12/site-packages (from requests<3.0.0,>=2.27.1->tableau-utilities) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /opt/homebrew/lib/python3.12/site-packages (from requests<3.0.0,>=2.27.1->tableau-utilities) (3.7)
Requirement already satisfied: urllib3<3,>=1.21.1 in /opt/homebrew/lib/python3.12/site-packages (from requests<3.0.0,>=2.27.1->tableau-utilities) (2.2.1)
Requirement already satisfied: certifi>=2017.4.17 in /opt/homebrew/lib/python3.12/site-packages (from requests<3.0.0,>=2.27.1->tableau-utilities) (2024.2.2)
Requirement already satisfied: six>=1.5 in /opt/homebrew/lib/python3.12/site-packages (from python-dateutil>=2.8.1->pandas<2.0.0,>=1.4.1->tableau-utilities) (1.16.0)
Downloading https://test-files.pythonhosted.org/packages/8d/ed/d13473417a2e2f06ff049a6d789bebdfd66432fda3568b5cff783a8cc29b/tableau_utilities-2.2.11-py3-none-any.whl (57 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 57.1/57.1 kB 2.1 MB/s eta 0:00:00
Installing collected packages: tableau-utilities
Successfully installed tableau-utilities-2.2.11
```

## Fails on Hyper subpackage as expected
```
➜  ~ pip install -i https://test.pypi.org/simple/ "tableau-utilities[hyper]"
Looking in indexes: https://test.pypi.org/simple/
Requirement already satisfied: tableau-utilities[hyper] in /opt/homebrew/lib/python3.12/site-packages (2.2.11)
Requirement already satisfied: xmltodict<1.0.0,>=0.12.0 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities[hyper]) (0.13.0)
Requirement already satisfied: pyyaml<7.0.0,>=6.0 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities[hyper]) (6.0.1)
Requirement already satisfied: requests<3.0.0,>=2.27.1 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities[hyper]) (2.31.0)
Requirement already satisfied: pandas<2.0.0,>=1.4.1 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities[hyper]) (1.5.3)
Requirement already satisfied: tabulate<1.0.0,>=0.8.9 in /opt/homebrew/lib/python3.12/site-packages (from tableau-utilities[hyper]) (0.9.0)
INFO: pip is looking at multiple versions of tableau-utilities[hyper] to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement tableauhyperapi==0.0.18825; extra == "hyper" (from tableau-utilities[hyper]) (from versions: none)
ERROR: No matching distribution found for tableauhyperapi==0.0.18825; extra == "hyper"
```

## cli succeeds with --help
```
➜  ~ tableau_utilities --help
usage: tableau_utilities [-h] [--version] [-d] [-s SERVER] [-sn SITE_NAME] [--api_version API_VERSION] [-u USER] [-p PASSWORD] [-ts TOKEN_SECRET]
                         [-tn TOKEN_NAME] [--settings_path SETTINGS_PATH] [-o OUTPUT_DIR] [-c] [-l {local,online}] [-i ID] [-n NAME]
                         [-pn PROJECT_NAME] [-f FILE_PATH] [--definitions_csv DEFINITIONS_CSV] [--include_extract] [-tds] [--conn_user CONN_USER]
                         [--conn_pw CONN_PW] [--conn_type CONN_TYPE] [--conn_db CONN_DB] [--conn_schema CONN_SCHEMA] [--conn_host CONN_HOST]
                         [--conn_role CONN_ROLE] [--conn_warehouse CONN_WAREHOUSE]
                         {server_info,server_operate,datasource,generate_config,csv_config,merge_config} ...

Tableau Utilities CLI:
-Manage Tableau Server/Online
-Manage configurations to edit datasource metadata

options:
  -h, --help            show this help message and exit
  --version             Print the current version of the CLI
  -d, --debugging_logs  Print detailed logging to the console to debug CLI

commands:
  {server_info,server_operate,datasource,generate_config,csv_config,merge_config}
                        You must choose a command.
    server_info         Retrieve and view information from Tableau Cloud/Server
    server_operate      Download, publish, and
...
```