### PR TITLE
Use importlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ tableau_utilities --token_name my_token_name --token_secret 1q2w3e4r5t6y7u8i9o -
 
 Generate a config from a local file. Add a file prefix and print the debugging logs to the console
 ```commandline
-tableau_utilities --debugging_logs generate_config --location local --file_path '/code/tableau-utilities/tmp_tdsx_and_config/My Awesome Datasource.tdsx' --file_prefix
+tableau_utilities --debugging_logs  --location local --file_path '/code/tableau-utilities/tmp_tdsx_and_config/My Awesome Datasource.tdsx' generate_config --file_prefix
 ```
 
 #### csv_config

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.2.0",
+    version="2.2.11",
     requires_python=">=3.8",
     packages=[
         'tableau_utilities',

--- a/tableau_utilities/scripts/cli.py
+++ b/tableau_utilities/scripts/cli.py
@@ -3,8 +3,6 @@ import os
 import shutil
 from argparse import RawTextHelpFormatter
 import yaml
-import pkg_resources
-import pkgutil
 import importlib.metadata
 
 import tableau_utilities.tableau_server.tableau_server as ts
@@ -18,7 +16,7 @@ from tableau_utilities.scripts.server_operate import server_operate
 from tableau_utilities.scripts.datasource import datasource
 from tableau_utilities.scripts.csv_config import csv_config
 
-__version__ = pkg_resources.require("tableau_utilities")[0].version
+__version__ = importlib.metadata.version('tableau_utilities')
 
 parser = argparse.ArgumentParser(
     prog='tableau_utilities',
@@ -27,7 +25,7 @@ parser = argparse.ArgumentParser(
                 '-Manage configurations to edit datasource metadata',
     formatter_class=RawTextHelpFormatter
 )
-parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}',
+parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {__version__}',
                     help='Print the current version of the CLI')
 parser.add_argument('-d', '--debugging_logs', action='store_true',
                     help='Print detailed logging to the console to debug CLI')

--- a/tableau_utilities/scripts/datasource.py
+++ b/tableau_utilities/scripts/datasource.py
@@ -9,7 +9,6 @@ from tableau_utilities.general.cli_styling import Color
 from tableau_utilities.general.cli_styling import Symbol
 from tableau_utilities.tableau_file.tableau_file import Datasource
 from tableau_utilities.tableau_server.tableau_server import TableauServer
-from tableau_utilities.hyper.hyper import create_empty_hyper_extract, filter_hyper_extract
 
 
 def datasource(args, server=None):
@@ -74,10 +73,12 @@ def datasource(args, server=None):
 
     # Add an empty .hyper file to the Datasource; Useful for publishing without data
     if empty_extract:
+        from tableau_utilities.hyper.hyper import create_empty_hyper_extract
         create_empty_hyper_extract(ds)
         print(f'{color.fg_green}Added empty .hyper extract for {datasource_path}{color.reset}')
     # Otherwise, filter the extract if filter_extract string provided
     elif filter_extract:
+        from tableau_utilities.hyper.hyper import filter_hyper_extract
         start = time()
         print(f'{color.fg_cyan}...Filtering extract data...{color.reset}')
         filter_hyper_extract(ds, filter_extract)


### PR DESCRIPTION
# Description

On installation there were sometimes errors due to missing `pkg_resources`.  That can be solved by `pip installing setuptools`.   That said, using importlib to get the version removes this dependency. https://docs.python.org/3/library/importlib.html is part of the standard base Python.

# Changes
* Get version using import_lib
* Add short flag for version
* Remove un-needed packages

# Tests
```
Successfully installed tableau_utilities-2.2.11
➜  tableau-utilities git:(use-importlib) ✗ tableau_utilities -v           
tableau_utilities 2.2.11
➜  tableau-utilities git:(use-importlib) ✗ tableau_utilities --version    
tableau_utilities 2.2.11
```