### PR TITLE
Release 2.2.13 - Layout, Group By Folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.2.11",
+    version="2.2.12",
     requires_python=">=3.8",
     packages=[
         'tableau_utilities',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.2.12",
+    version="2.2.13",
     requires_python=">=3.8",
     packages=[
         'tableau_utilities',

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -261,7 +261,6 @@ class Datasource(TableauFile):
             # Set display to show folders
             self.layout.show_structure=False
 
-
         # If a remote_name was provided, and the column is not a Tableau Calculation - enforce metadata
         if not remote_name or column.calculation:
             return None

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -185,7 +185,7 @@ class Datasource(TableauFile):
         Returns: A list of (index, Element) for the elements removed from the parent Element
         """
         # A section can be multiple elements within the parent element
-        elements = [(i, e) for i, e in enumerate(parent) if e.tag.endswith(f'true...{tag}') or e.tag == tag]
+        elements = [(i, e) for i, e in enumerate(parent) if e.tag.endswith(f'true...{tag}') or e.tag == tag or (e.tag.startswith(f'layout _.fcp.SchemaViewerObjectModel.false...') and tag == 'layout')]
         for _, e in elements:
             parent.remove(e)
         return elements
@@ -201,7 +201,7 @@ class Datasource(TableauFile):
         # Gets elements within the parent element, with the appropriate section.tag
         section: list[dict] = list()
         for element in parent:
-            if element.tag.endswith(f'true...{obj.tag}') or element.tag == obj.tag:
+            if element.tag.endswith(f'true...{obj.tag}') or element.tag == obj.tag or (element.tag.startswith(f'layout _.fcp.SchemaViewerObjectModel.false...') and obj.tag == 'layout'):
                 item = xmltodict.parse(ET.tostring(element))[element.tag]
                 if not item:
                     continue
@@ -259,8 +259,7 @@ class Datasource(TableauFile):
                 self.folders_common.folder.add(tfo.Folder(name=folder_name, folder_item=[folder_item]))
 
             # Set display to show folders
-            self.layout.update(show_structure='true')
-
+            self.layout.show_structure=False
 
 
         # If a remote_name was provided, and the column is not a Tableau Calculation - enforce metadata

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -151,6 +151,7 @@ class Datasource(TableauFile):
         self.folders_common: tfo.FoldersCommon = self.__get_section(tfo.FoldersCommon)
         self.date_options: tfo.DateOptions = self.__get_section(tfo.DateOptions)
         self.extract: tfo.Extract = self.__get_section(tfo.Extract)
+        self.layout: tfo.Layout = self.__get_section(tfo.Layout)
 
     def __delattr__(self, attr):
         section = getattr(self, attr)
@@ -172,6 +173,7 @@ class Datasource(TableauFile):
         yield self.folders_common
         yield self.date_options
         yield self.extract
+        yield self.layout
 
     @staticmethod
     def __remove_section_from_parent(parent, tag) -> list[tuple[int, ET.Element]]:
@@ -198,7 +200,11 @@ class Datasource(TableauFile):
         parent = self._root.find('.')
         # Gets elements within the parent element, with the appropriate section.tag
         section: list[dict] = list()
+        print('-'*50)
+        print(section)
         for element in parent:
+            print('-------------ELEMENT')
+            print(section)
             if element.tag.endswith(f'true...{obj.tag}') or element.tag == obj.tag:
                 item = xmltodict.parse(ET.tostring(element))[element.tag]
                 if not item:
@@ -224,6 +230,7 @@ class Datasource(TableauFile):
                     - Create the folder if it doesn't exist
                 - Updating the metadata local-name to map to the column name
                 - Adding the column mapping to the mapping cols, if it doesn't exist
+                - Displaying the folders and sorting columns alphabetically
 
         Args:
             column (tfo.Column): The TableFile Column object
@@ -254,6 +261,11 @@ class Datasource(TableauFile):
                 self.folders_common.folder.update(folder)
             elif not folder:
                 self.folders_common.folder.add(tfo.Folder(name=folder_name, folder_item=[folder_item]))
+
+            # Set display to show folders
+            self.layout.update(show_structure='true')
+
+
 
         # If a remote_name was provided, and the column is not a Tableau Calculation - enforce metadata
         if not remote_name or column.calculation:

--- a/tableau_utilities/tableau_file/tableau_file.py
+++ b/tableau_utilities/tableau_file/tableau_file.py
@@ -200,11 +200,7 @@ class Datasource(TableauFile):
         parent = self._root.find('.')
         # Gets elements within the parent element, with the appropriate section.tag
         section: list[dict] = list()
-        print('-'*50)
-        print(section)
         for element in parent:
-            print('-------------ELEMENT')
-            print(section)
             if element.tag.endswith(f'true...{obj.tag}') or element.tag == obj.tag:
                 item = xmltodict.parse(ET.tostring(element))[element.tag]
                 if not item:

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -69,6 +69,7 @@ class TableauFileObject:
         self.__to_bool('hidden')
         self.__to_bool('incremental_updates')
         self.__to_bool('user_specific')
+        self.__to_bool('show_structure')
         # Convert to Integer
         self.__to_int('approx_count')
         self.__to_int('collation_flag')
@@ -1074,8 +1075,8 @@ class Extract(TableauFileObject):
 @dataclass
 class Layout(TableauFileObject):
     """ The Layout Tableau file object """
-    dim_percentage: str = None
-    measure_percentage: str = None
+    # dim_percentage: str = None
+    # measure_percentage: str = None
     dim_ordering: str = None # ordinal or alphabetic
     measure_ordering: str = None # ordinal or alphabetic
     show_structure: bool = None
@@ -1094,6 +1095,13 @@ class Layout(TableauFileObject):
         if self.show_structure is not None:
             dictionary['@show-structure'] = str(self.show_structure).lower()
         return dictionary
+
+    def xml(self):
+        """ Returns the FileObject as an XML Element """
+        this_xml =  ET.fromstring(xmltodict.unparse({self.tag: self.dict()}, pretty=True))
+        print(this_xml) # make this have all that ... stuff
+
+        return this_xml
 
 @dataclass
 class Aliases(TableauFileObject):

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -1099,10 +1099,6 @@ class Layout(TableauFileObject):
     def xml(self):
         """ Returns the FileObject as an XML Element """
         this_xml =  ET.fromstring(xmltodict.unparse({self.tag: self.dict()}, pretty=True))
-        print("i am in the layout xml")
-        print(this_xml) # make this have all that ... stuff
-        print(ET.tostring(this_xml, encoding='unicode'))  # Print the raw XML
-
         return this_xml
 
 @dataclass

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -1075,8 +1075,8 @@ class Extract(TableauFileObject):
 @dataclass
 class Layout(TableauFileObject):
     """ The Layout Tableau file object """
-    # dim_percentage: str = None
-    # measure_percentage: str = None
+    dim_percentage: str = None
+    measure_percentage: str = None
     dim_ordering: str = None # ordinal or alphabetic
     measure_ordering: str = None # ordinal or alphabetic
     show_structure: bool = None
@@ -1085,9 +1085,9 @@ class Layout(TableauFileObject):
     def dict(self):
         dictionary = dict()
         if self.dim_percentage is not None:
-            dictionary['@dim-percentage'] = self.dim_percentage
+            dictionary['@_.fcp.SchemaViewerObjectModel.false...dim-percentage'] = self.dim_percentage
         if self.measure_percentage is not None:
-            dictionary['@measure-percentage'] = self.measure_percentage
+            dictionary['@_.fcp.SchemaViewerObjectModel.false...measure-percentage'] = self.measure_percentage
         if self.dim_ordering is not None:
             dictionary['@dim-ordering'] = self.dim_ordering
         if self.measure_ordering is not None:
@@ -1099,7 +1099,9 @@ class Layout(TableauFileObject):
     def xml(self):
         """ Returns the FileObject as an XML Element """
         this_xml =  ET.fromstring(xmltodict.unparse({self.tag: self.dict()}, pretty=True))
+        print("i am in the layout xml")
         print(this_xml) # make this have all that ... stuff
+        print(ET.tostring(this_xml, encoding='unicode'))  # Print the raw XML
 
         return this_xml
 

--- a/tableau_utilities/tableau_file/tableau_file_objects.py
+++ b/tableau_utilities/tableau_file/tableau_file_objects.py
@@ -1072,6 +1072,30 @@ class Extract(TableauFileObject):
 
 
 @dataclass
+class Layout(TableauFileObject):
+    """ The Layout Tableau file object """
+    dim_percentage: str = None
+    measure_percentage: str = None
+    dim_ordering: str = None # ordinal or alphabetic
+    measure_ordering: str = None # ordinal or alphabetic
+    show_structure: bool = None
+    tag: str = 'layout'
+
+    def dict(self):
+        dictionary = dict()
+        if self.dim_percentage is not None:
+            dictionary['@dim-percentage'] = self.dim_percentage
+        if self.measure_percentage is not None:
+            dictionary['@measure-percentage'] = self.measure_percentage
+        if self.dim_ordering is not None:
+            dictionary['@dim-ordering'] = self.dim_ordering
+        if self.measure_ordering is not None:
+            dictionary['@measure-ordering'] = self.measure_ordering
+        if self.show_structure is not None:
+            dictionary['@show-structure'] = str(self.show_structure).lower()
+        return dictionary
+
+@dataclass
 class Aliases(TableauFileObject):
     """ The Aliases Tableau file object """
     enabled: bool = True


### PR DESCRIPTION
# Overview
By default a Tableau data extract is set to "Group By Datasource Table."  When using the cli we can add a folder but then it's still not visible when you open the datasource in Tableau.  This adds a show folders setting to enforce columns to make the display show folders.
<img width="289" alt="image" src="https://github.com/hoverinc/tableau-utilities/assets/9727812/693e52c1-c1d3-4872-80d9-c262170aabd8">

```
   <layout _.fcp.SchemaViewerObjectModel.false...dim-percentage='0.5' _.fcp.SchemaViewerObjectModel.false...measure-percentage='0.4' dim-ordering='ordinal' measure-ordering='ordinal' show-structure='false' />
   ```


# Changes
* Add a Layout class
* Set `show-structure='false'` when running enforce column


# Testing

## Before
<img width="424" alt="image" src="https://github.com/user-attachments/assets/27da5c8d-4432-41f5-b31a-f0fe74d9c774" />

## After
<img width="396" alt="image" src="https://github.com/user-attachments/assets/ddcf75dc-2a96-4be0-97f9-f540d1795aa5" />

<img width="358" alt="image" src="https://github.com/user-attachments/assets/ae9cb320-fe6e-4e66-a3e4-7a9c9f69920b" />
