### PR TITLE
Fixed bugs encountered while querying secondary Tableau Online environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.2.12",
+    version="2.2.13",
     requires_python=">=3.8",
     packages=[
         'tableau_utilities',

--- a/tableau_utilities/tableau_server/get.py
+++ b/tableau_utilities/tableau_server/get.py
@@ -158,24 +158,27 @@ class Get(Base):
         v = v['view']
         return tso.View(**v)
 
-    def projects(self, top_level_only=True):
+    def projects(self, top_level_only=True, include_extra_fields=True):
         """ Queries for all projects in the site
             URI GET /api/api-version/sites/site-id/projects
         Args:
             top_level_only (bool): True to only get top level projects
+            include_extra_fields (bool): True to include extra fields not provided in the default query
         Returns: All top level projects in the site
         """
-        url = f"{self.url}/projects?fields=_default_" \
+        if include_extra_fields:
+            url = f"{self.url}/projects?fields=_default_" \
               f",topLevelProject" \
               f",writeable" \
               f",contentsCounts.projectCount" \
               f",contentsCounts.viewCount" \
               f",contentsCounts.datasourceCount" \
               f",contentsCounts.workbookCount"
+        else:
+            url = f"{self.url}/projects"
         for p in self.__get_objects_pager(url, 'project'):
             project = tso.Project(**p)
-            # Only get Top Level projects
-            if top_level_only and not project.top_level_project:
+            if top_level_only and project.parent_project_id:
                 continue
             yield project
 

--- a/tableau_utilities/tableau_server/publish.py
+++ b/tableau_utilities/tableau_server/publish.py
@@ -39,12 +39,12 @@ class Publish(Base):
             return self.get.datasource(datasource_id)
         elif datasource_name and project_name:
             project = None
-            for p in self.get.projects():
+            for p in self.get.projects(False, False):
                 if p.name == project_name:
                     project = p
                     break
             if not project:
-                raise TableauConnectionError(f'Project does not exist: {project}')
+                raise TableauConnectionError(f'Project does not exist: {project_name}')
             return tso.Datasource(
                 name=datasource_name,
                 project_id=project.id,
@@ -58,12 +58,12 @@ class Publish(Base):
             return self.get.workbook(workbook_id)
         elif workbook_name and project_name:
             project = None
-            for p in self.get.projects():
+            for p in self.get.projects(False, False):
                 if p.name == project_name:
                     project = p
                     break
             if not project:
-                raise TableauConnectionError(f'Project does not exist: {project}')
+                raise TableauConnectionError(f'Project does not exist: {project_name}')
             return tso.Workbook(
                 name=workbook_name,
                 project_id=project.id,


### PR DESCRIPTION
# Overview
We encountered bugs while attempting to query projects in our secondary Tableau Online environment.
Not entirely sure why we do not have the same errors while querying our Production environment, but I assume it is because our Production enviroment has been around for long time, and newer environments don't support some legacy API endpoint parameters.

# Changes
* Changes to the `get.projects` functionality:
  * Added option for `include_extra_fields`, as some environments are clearly capable of including these extra fields, while others will error
    * Defaulting to True for now, as existing implementations expect these fields to be included
  * Changed "top_level" to be identified by if the project has a `parent_project_id`, as `topLevelProject` is not included by default
* Changed `publish.datasource` and `publish.datasource` to allow publishing to sub-projects by name, if no ID is provided
  * Also fixed a small printing bug, where it would print the `None` project, rather than the `project_name` it was searching for, when no project was found

# Testing
- Ran script locally on both our Production and Staging Tableau Online environments, with all variations of the updated arguments
  - Script was able to both query and publish with these changes