### PR TITLE
CLI: Set target directory to absolute to override general working dir…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     name="tableau_utilities",
-    version="2.2.14",
+    version="2.2.15",
     requires_python=">=3.8",
     packages=[
         'tableau_utilities',

--- a/tableau_utilities/scripts/cli.py
+++ b/tableau_utilities/scripts/cli.py
@@ -458,6 +458,9 @@ def main():
     if not os.path.isabs(args.settings_path) and os.path.exists(args.settings_path):
         args.settings_path = os.path.abspath(args.settings_path)
 
+    if args.target_directory and not os.path.isabs(args.target_directory):
+        args.target_directory = os.path.abspath(args.target_directory)
+
     # Set args from connection group, from settings YAML / Environment Variables, when not provided in the command
     set_datasource_connection_args(args)
 
@@ -474,6 +477,8 @@ def main():
         validate_args_command_merge_config(args)
     if args.command == 'apply_configs':
         validate_args_command_apply_configs(args)
+
+    # Make the target directory path absolute to avoid conflicts with the working directory
 
     # Set/Reset the directory
     tmp_folder = args.output_dir

--- a/tableau_utilities/scripts/merge_config.py
+++ b/tableau_utilities/scripts/merge_config.py
@@ -1,4 +1,5 @@
 import json
+import os
 from tableau_utilities.general.cli_styling import Color, Symbol
 from tableau_utilities.scripts.gen_config import load_csv_with_definitions, generate_config
 
@@ -15,6 +16,10 @@ def read_file(file_path):
     Returns:
         dict: The JSON content as a dictionary.
     """
+
+    # # Convert relative path to absolute path
+    # file_path = os.path.abspath(file_path)
+
     try:
         with open(file_path, "r") as infile:
             config = json.load(infile)
@@ -158,6 +163,8 @@ def read_merge_write(existing_config_path, additional_config_path, output_config
     existing_config = read_file(existing_config_path)
     additional_config = read_file(additional_config_path)
 
+    print(existing_config)
+
     # Merge
     new_config = merge_2_configs(existing_config, additional_config, debugging_logs)
 
@@ -229,8 +236,21 @@ def merge_configs(args, server=None):
               f'{COLOR.fg_grey}{new_column_config_path} {SYMBOL.sep} {new_calculated_column_config_path}{COLOR.reset}')
         print(f'{COLOR.fg_yellow}TARGET DIRECTORY {SYMBOL.arrow_r} {COLOR.fg_grey}{target_directory}{COLOR.reset}')
 
-        existing_column_config_path = f'{target_directory}column_config.json'
-        existing_calc_config_path = f'{target_directory}tableau_calc_config.json'
+        # existing_column_config_path = f'{target_directory}column_config.json'
+        # existing_calc_config_path = f'{target_directory}tableau_calc_config.json'
+
+        # Get the current working directory
+        current_working_directory = os.getcwd()
+
+        # Print the full path of the current working directory
+        print(f"Current working directory: {current_working_directory}")
+
+        existing_column_config_path = os.path.join(target_directory, 'column_config.json')
+        existing_calc_config_path = os.path.join(target_directory, 'tableau_calc_config.json')
+
+        print('I am before read_merge_write')
+        print(existing_column_config_path)
+        print(existing_calc_config_path)
 
         read_merge_write(existing_config_path=existing_column_config_path,
                          additional_config_path=new_column_config_path,


### PR DESCRIPTION
# Overview

The cli is having issues because it needs to write tmp files to `tmp_tdsx_and_config` but needs the final files to write to a different directory

# Changes

- set target directory to and absolute path before the working directory changes are made
- bump version


# Testing
This works:
```
tableau_utilities --location local --name "My Datasource" --file_path "My Datasource.tds" merge_config --merge_with generate_merge_all --target_directory tableau_configs/


```
EXISTING CONFIG → /Users/jay.rosenthal/code/dbt-finance/tableau_configs/tableau_calc_config.json
ADDITIONAL CONFIG → tableau_calc_config.json
✅  MERGED CONFIG → /Users/jay.rosenthal/code/dbt-finance/tableau_configs/tableau_calc_config.json
(env) ➜  dbt-finance git:(tableau-configs) ✗ 
```
