### PR TITLE
[SECENG-364] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  commit-message:
+    prefix: "[bot] "
+  cooldown:
+    default-days: 7
+  schedule:
+    interval: "weekly"
+    day: "wednesday"
+    time: "11:00"
+    timezone: "America/Los_Angeles"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
## Ticket
[SECENG-364](https://hoverinc.atlassian.net/browse/SECENG-364)

## Summary

Pin all external GitHub Actions to commit SHAs for supply chain security. Internal (hoverinc/) actions are left unpinned.

### Pinned Actions

  - `actions/checkout@v3` → [`f43a0e5f`](https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744)
  - `actions/setup-python@v3` → [`3542bca2`](https://github.com/actions/setup-python/commit/3542bca2639a428e1796aaa6a2ffef0c0f575566)

### Dependabot

Added/updated `dependabot.yml` to keep GitHub Actions pinned to the latest SHA with a 7-day update cooldown.


[SECENG-364]: https://hoverinc.atlassian.net/browse/SECENG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ